### PR TITLE
feature/21 - Masonite Scheduling

### DIFF
--- a/src/masonite/commands/QueueRetryCommand.py
+++ b/src/masonite/commands/QueueRetryCommand.py
@@ -17,7 +17,7 @@ class QueueRetryCommand(Command):
         self.app = application
 
     def handle(self):
-        driver = None if driver == "None" else self.option("driver")
+        driver = None if self.option("driver") == "None" else self.option("driver")
 
         return self.app.make("queue").retry(
             {

--- a/src/masonite/commands/QueueTableCommand.py
+++ b/src/masonite/commands/QueueTableCommand.py
@@ -25,8 +25,6 @@ class QueueTableCommand(Command):
             )
         ) as fp:
             output = fp.read()
-            # output = output.replace("__MIGRATION_NAME__", camelize(name))
-            # output = output.replace("__TABLE_NAME__", table)
 
         file_name = f"{now.strftime('%Y_%m_%d_%H%M%S')}_create_queue_jobs_table.py"
 

--- a/src/masonite/commands/QueueWorkCommand.py
+++ b/src/masonite/commands/QueueWorkCommand.py
@@ -20,7 +20,7 @@ class QueueWorkCommand(Command):
 
     def handle(self):
         options = {}
-        driver = None if driver == "None" else self.option("driver")
+        driver = None if self.option("driver") == "None" else self.option("driver")
 
         options.update({"driver": driver})
         if self.option("poll") != "None":

--- a/src/masonite/scheduling/CanSchedule.py
+++ b/src/masonite/scheduling/CanSchedule.py
@@ -1,0 +1,10 @@
+class CanSchedule:
+    def call(self, command):
+        command_class = CommandTask(command)
+        self.app.simple(command_class)
+        return command_class
+
+    def schedule(self, task):
+        task_class = task
+        self.app.simple(task_class)
+        return task_class

--- a/src/masonite/scheduling/CanSchedule.py
+++ b/src/masonite/scheduling/CanSchedule.py
@@ -1,10 +1,10 @@
 class CanSchedule:
     def call(self, command):
         command_class = CommandTask(command)
-        self.app.simple(command_class)
+        self.app.make("scheduler").add(command_class)
         return command_class
 
     def schedule(self, task):
         task_class = task
-        self.app.simple(task_class)
+        self.app.make("scheduler").add(task_class)
         return task_class

--- a/src/masonite/scheduling/CommandTask.py
+++ b/src/masonite/scheduling/CommandTask.py
@@ -1,0 +1,13 @@
+from .Task import Task
+import subprocess
+
+
+class CommandTask(Task):
+
+    run_every_minute = True
+
+    def __init__(self, command=""):
+        self.command = command
+
+    def handle(self):
+        subprocess.call(self.command.split(" "))

--- a/src/masonite/scheduling/Task.py
+++ b/src/masonite/scheduling/Task.py
@@ -125,8 +125,7 @@ class Task:
             return self._verify_run_at()
 
         if self.run_every_minute:
-            if self._date.minute / 1 == 1:
-                return True
+            return True
         elif self.run_every_hour:
             if self._date.hour / 1 == 1:
                 return True

--- a/src/masonite/scheduling/Task.py
+++ b/src/masonite/scheduling/Task.py
@@ -1,0 +1,161 @@
+import pendulum
+
+
+class Task:
+
+    run_every = False
+    run_at = False
+    run_every_hour = False
+    run_every_minute = False
+    twice_daily = False
+    run_weekly = False
+
+    _date = None
+
+    name = ""
+
+    def __init__(self):
+        """
+        Should only be on the child class. Also needs to be resolved by the container.
+        """
+
+        pass
+
+    def every(self, time):
+        self.run_every = time
+        return self
+
+    def every_minute(self):
+        self.run_every = "1 minute"
+        return self
+
+    def every_15_minutes(self):
+        self.run_every = "15 minutes"
+        return self
+
+    def every_30_minutes(self):
+        self.run_every = "15 minutes"
+        return self
+
+    def every_45_minutes(self):
+        self.run_every = "15 minutes"
+        return self
+
+    def hourly(self):
+        self.run_every = "1 hour"
+        return self
+
+    def daily(self):
+        self.run_every = "1 day"
+        return self
+
+    def weekly(self):
+        self.run_every = "1 week"
+        return self
+
+    def monthly(self):
+        self.run_every = "1 month"
+        return self
+
+    def at(self, run_time):
+        self.run_at = run_time
+        return self
+
+    def daily_at(self, run_time):
+        return self.daily().at(run_time)
+
+    def handle(self):
+        """
+        Fires the task
+        """
+
+        pass
+
+    def log(self):
+        """
+        Log into scheduler cache
+        """
+        pass
+
+    def should_run(self, date=None):
+        """
+        If the task should run
+        """
+
+        # set the date
+        self._set_date()
+
+        if self._verify_run():
+            return True
+
+        return False
+
+    def _set_date(self):
+        if not self._date:
+            self._date = pendulum.now()
+            if hasattr(self, "timezone"):
+                self._date.in_timezone(self.timezone)
+
+    def _verify_run(self):
+        if self.run_every:
+            time = self.run_every.split(" ")
+
+            if time[1] in ("minute", "minutes"):
+                time = int(time[0])
+                if self._date.minute == 0 or self._date.minute % time == 0 or time == 1:
+                    return True
+
+            elif time[1] in ("hour", "hours"):
+                time = int(time[0])
+                if self._date.hour % time == 0 and self._date.minute == 0:
+                    return True
+
+            elif time[1] in ("day", "days"):
+                time = int(time[0])
+                if self._date.day_of_year % time == 0 and (
+                    self._date.hour == 0
+                    and self._date.minute == 0
+                    or self._verify_run_at()
+                ):
+                    return True
+            elif time[1] in ("month", "months"):
+                time = int(time[0])
+                if (
+                    self._date.month % time == 0
+                    and self._date.day == 1
+                    and (
+                        self._date.hour == 0
+                        and self._date.minute == 0
+                        or (self._date.day == 0 and self._verify_run_at())
+                    )
+                ):
+                    return True
+
+        elif self.run_at:
+            return self._verify_run_at()
+
+        if self.run_every_minute:
+            if self._date.minute / 1 == 1:
+                return True
+        elif self.run_every_hour:
+            if self._date.hour / 1 == 1:
+                return True
+        elif self.twice_daily:
+            if self._date.hour in self.twice_daily:
+                return True
+
+        return False
+
+    def _verify_run_every():
+        pass
+
+    def _verify_run_at(self):
+        if self._date.minute < 10:
+            minute = "0{}".format(self._date.minute)
+        else:
+            minute = self._date.minute
+
+        if "{0}:{1}".format(self._date.hour, minute) == self.run_at:
+            return True
+
+        return False

--- a/src/masonite/scheduling/Task.py
+++ b/src/masonite/scheduling/Task.py
@@ -75,10 +75,7 @@ class Task:
         # set the date
         self._set_date()
 
-        if self._verify_run():
-            return True
-
-        return False
+        return self._verify_run()
 
     def _set_date(self):
         if not self._date:

--- a/src/masonite/scheduling/Task.py
+++ b/src/masonite/scheduling/Task.py
@@ -65,22 +65,12 @@ class Task:
         return self.daily().at(run_time)
 
     def handle(self):
-        """
-        Fires the task
-        """
+        """Fires the task"""
 
-        pass
-
-    def log(self):
-        """
-        Log into scheduler cache
-        """
         pass
 
     def should_run(self, date=None):
-        """
-        If the task should run
-        """
+        """If the task should run"""
 
         # set the date
         self._set_date()
@@ -98,28 +88,28 @@ class Task:
 
     def _verify_run(self):
         if self.run_every:
-            time = self.run_every.split(" ")
+            length, frequency = self.run_every.split(" ")
 
-            if time[1] in ("minute", "minutes"):
-                time = int(time[0])
+            if frequency in ("minute", "minutes"):
+                time = int(length)
                 if self._date.minute == 0 or self._date.minute % time == 0 or time == 1:
                     return True
 
-            elif time[1] in ("hour", "hours"):
-                time = int(time[0])
+            elif frequency in ("hour", "hours"):
+                time = int(length)
                 if self._date.hour % time == 0 and self._date.minute == 0:
                     return True
 
-            elif time[1] in ("day", "days"):
-                time = int(time[0])
+            elif frequency in ("day", "days"):
+                time = int(length)
                 if self._date.day_of_year % time == 0 and (
                     self._date.hour == 0
                     and self._date.minute == 0
                     or self._verify_run_at()
                 ):
                     return True
-            elif time[1] in ("month", "months"):
-                time = int(time[0])
+            elif frequency in ("month", "months"):
+                time = int(length)
                 if (
                     self._date.month % time == 0
                     and self._date.day == 1
@@ -146,16 +136,13 @@ class Task:
 
         return False
 
-    def _verify_run_every():
-        pass
-
     def _verify_run_at(self):
         if self._date.minute < 10:
-            minute = "0{}".format(self._date.minute)
+            minute = f"0{self._date.minute}"
         else:
             minute = self._date.minute
 
-        if "{0}:{1}".format(self._date.hour, minute) == self.run_at:
+        if f"{self._date.hour}:{minute}" == self.run_at:
             return True
 
         return False

--- a/src/masonite/scheduling/TaskHandler.py
+++ b/src/masonite/scheduling/TaskHandler.py
@@ -1,0 +1,30 @@
+import pendulum
+import inspect
+
+
+class TaskHandler:
+    def __init__(self, application, tasks=None):
+        if tasks is None:
+            tasks = []
+
+        self.tasks = tasks
+        self.application = application
+
+    def add(self, *tasks):
+        self.tasks += list(tasks)
+
+    def run(self, run_name=None):
+        app = self.application
+        for task_class in self.tasks:
+            # Resolve the task with the container
+            if run_name and run_name != task_class.name:
+                continue
+
+            if inspect.isclass(task_class):
+                task = app.resolve(task_class)
+            else:
+                task = task_class
+
+            # If the class should run then run it
+            if task.should_run():
+                task.handle()

--- a/src/masonite/scheduling/__init__.py
+++ b/src/masonite/scheduling/__init__.py
@@ -1,0 +1,3 @@
+from .CanSchedule import CanSchedule
+from .CommandTask import CommandTask
+from .Task import Task

--- a/src/masonite/scheduling/__init__.py
+++ b/src/masonite/scheduling/__init__.py
@@ -1,3 +1,4 @@
 from .CanSchedule import CanSchedule
 from .CommandTask import CommandTask
 from .Task import Task
+from .TaskHandler import TaskHandler

--- a/src/masonite/scheduling/commands/CreateTaskCommand.py
+++ b/src/masonite/scheduling/commands/CreateTaskCommand.py
@@ -2,6 +2,10 @@
 import os
 
 from cleo import Command
+import inflection
+from ...utils.filesystem import make_directory
+import os
+from pathlib import Path
 
 
 class CreateTaskCommand(Command):
@@ -9,25 +13,27 @@ class CreateTaskCommand(Command):
     Create a new task
     task
         {name : Name of the task you want to create}
+        {--d|--directory=app/tasks : Specifies the directory to create the task in}
     """
 
     def handle(self):
-        task = self.argument("name")
-        if not os.path.isfile("app/tasks/{0}.py".format(task)):
-            if not os.path.exists(os.path.dirname("app/tasks/{0}.py".format(task))):
-                # Create the path to the Task if it does not exist
-                os.makedirs(os.path.dirname("app/tasks/{0}.py".format(task)))
-
-            f = open("app/tasks/{0}.py".format(task), "w+")
-
-            f.write("''' Task Module Description '''\n")
-            f.write("from masonite.scheduler.Task import Task\n\n")
-            f.write(
-                "class {0}(Task):\n    ''' Task description '''\n\n    ".format(task)
+        name = inflection.camelize(self.argument("name"))
+        with open(
+            os.path.join(
+                Path(__file__).parent.absolute(),
+                "../../",
+                "stubs/scheduling/task.py",
             )
-            f.write("def __init__(self):\n        pass\n\n    ")
-            f.write("def handle(self):\n        pass\n")
+        ) as fp:
+            output = fp.read().replace("__class__", name)
 
-            self.info("Task Created Successfully!")
-        else:
-            self.error("Task Already Exists!")
+        path = os.path.join(os.getcwd(), self.option("directory"), f"{name}.py")
+
+        if Path(path).exists():
+            return self.line_error(f"Task already exists at: {path}", style="error")
+        make_directory(path)
+
+        with open(path, "w") as fp:
+            fp.write(output)
+
+        self.info(f"Task file created: {path}")

--- a/src/masonite/scheduling/commands/CreateTaskCommand.py
+++ b/src/masonite/scheduling/commands/CreateTaskCommand.py
@@ -1,0 +1,33 @@
+""" A CreateTask Command """
+import os
+
+from cleo import Command
+
+
+class CreateTaskCommand(Command):
+    """
+    Create a new task
+    task
+        {name : Name of the task you want to create}
+    """
+
+    def handle(self):
+        task = self.argument("name")
+        if not os.path.isfile("app/tasks/{0}.py".format(task)):
+            if not os.path.exists(os.path.dirname("app/tasks/{0}.py".format(task))):
+                # Create the path to the Task if it does not exist
+                os.makedirs(os.path.dirname("app/tasks/{0}.py".format(task)))
+
+            f = open("app/tasks/{0}.py".format(task), "w+")
+
+            f.write("''' Task Module Description '''\n")
+            f.write("from masonite.scheduler.Task import Task\n\n")
+            f.write(
+                "class {0}(Task):\n    ''' Task description '''\n\n    ".format(task)
+            )
+            f.write("def __init__(self):\n        pass\n\n    ")
+            f.write("def handle(self):\n        pass\n")
+
+            self.info("Task Created Successfully!")
+        else:
+            self.error("Task Already Exists!")

--- a/src/masonite/scheduling/commands/ScheduleRunCommand.py
+++ b/src/masonite/scheduling/commands/ScheduleRunCommand.py
@@ -1,0 +1,37 @@
+""" A ScheduleRunCommand Command """
+import pendulum
+import inspect
+from cleo import Command
+
+from ..Task import Task
+
+
+class ScheduleRunCommand(Command):
+    """
+    Run the scheduled tasks
+    schedule:run
+        {--t|task=None : Name of task you want to run}
+    """
+
+    def handle(self):
+        from wsgi import container as app
+
+        tasks = app.collect(Task)
+
+        for task_key, task_class in tasks.items():
+            # Resolve the task with the container
+            if self.option("task") != "None":
+                if (
+                    self.option("task") != task_key
+                    and self.option("task") != task_class.name
+                ):
+                    continue
+
+            if inspect.isclass(task_class):
+                task = app.resolve(task_class)
+            else:
+                task = task_class
+
+            # If the class should run then run it
+            if task.should_run():
+                task.handle()

--- a/src/masonite/scheduling/commands/ScheduleRunCommand.py
+++ b/src/masonite/scheduling/commands/ScheduleRunCommand.py
@@ -18,24 +18,4 @@ class ScheduleRunCommand(Command):
         self.app = application
 
     def handle(self):
-        return self.run_tasks(self.app.collect(Task))
-
-    def run_tasks(self, tasks):
-        app = self.app
-        for name, task_class in tasks.items():
-            # Resolve the task with the container
-            if self.option("task") != "None":
-                if (
-                    self.option("task") != name
-                    and self.option("task") != task_class.name
-                ):
-                    continue
-
-            if inspect.isclass(task_class):
-                task = app.resolve(task_class)
-            else:
-                task = task_class
-
-            # If the class should run then run it
-            if task.should_run():
-                task.handle()
+        return self.app.make("scheduler").run()

--- a/src/masonite/scheduling/commands/ScheduleRunCommand.py
+++ b/src/masonite/scheduling/commands/ScheduleRunCommand.py
@@ -13,16 +13,20 @@ class ScheduleRunCommand(Command):
         {--t|task=None : Name of task you want to run}
     """
 
+    def __init__(self, application):
+        super().__init__()
+        self.app = application
+
     def handle(self):
-        from wsgi import container as app
+        return self.run_tasks(self.app.collect(Task))
 
-        tasks = app.collect(Task)
-
-        for task_key, task_class in tasks.items():
+    def run_tasks(self, tasks):
+        app = self.app
+        for name, task_class in tasks.items():
             # Resolve the task with the container
             if self.option("task") != "None":
                 if (
-                    self.option("task") != task_key
+                    self.option("task") != name
                     and self.option("task") != task_class.name
                 ):
                     continue

--- a/src/masonite/scheduling/commands/__init__.py
+++ b/src/masonite/scheduling/commands/__init__.py
@@ -1,0 +1,2 @@
+from .CreateTaskCommand import CreateTaskCommand
+from .ScheduleRunCommand import ScheduleRunCommand

--- a/src/masonite/scheduling/providers/ScheduleProvider.py
+++ b/src/masonite/scheduling/providers/ScheduleProvider.py
@@ -4,6 +4,7 @@ from ...providers import Provider
 from ..commands.CreateTaskCommand import CreateTaskCommand
 from ..commands.ScheduleRunCommand import ScheduleRunCommand
 from ..CommandTask import CommandTask
+from ..TaskHandler import TaskHandler
 
 
 class ScheduleProvider(Provider):
@@ -14,6 +15,8 @@ class ScheduleProvider(Provider):
         self.application.make("commands").add(
             CreateTaskCommand(), ScheduleRunCommand(self.application)
         )
+
+        self.application.bind("scheduler", TaskHandler(self.application))
 
     def boot(self):
         pass

--- a/src/masonite/scheduling/providers/ScheduleProvider.py
+++ b/src/masonite/scheduling/providers/ScheduleProvider.py
@@ -1,0 +1,19 @@
+""" A ScheduleProvider Service Provider """
+from ...providers import Provider
+
+from ..commands.CreateTaskCommand import CreateTaskCommand
+from ..commands.ScheduleRunCommand import ScheduleRunCommand
+from ..CommandTask import CommandTask
+
+
+class ScheduleProvider(Provider):
+    def __init__(self, application):
+        self.application = application
+
+    def register(self):
+        self.application.make("commands").add(
+            CreateTaskCommand(), ScheduleRunCommand(self.application)
+        )
+
+    def boot(self):
+        pass

--- a/src/masonite/scheduling/providers/__init__.py
+++ b/src/masonite/scheduling/providers/__init__.py
@@ -1,0 +1,1 @@
+from .ScheduleProvider import ScheduleProvider

--- a/src/masonite/stubs/scheduling/task.py
+++ b/src/masonite/stubs/scheduling/task.py
@@ -1,0 +1,7 @@
+"""Task Module Description"""
+from masonite.scheduling import Task
+
+
+class __class__(Task):
+    def handle(self):
+        pass

--- a/tests/features/scheduling/test_handler.py
+++ b/tests/features/scheduling/test_handler.py
@@ -1,0 +1,27 @@
+import pytest
+import pendulum
+from src.masonite.scheduling import TaskHandler, Task
+from tests import TestCase
+
+
+class MockTask1(Task):
+    run_every = "1 minutes"
+    timezone = "America/New_York"
+
+    def handle(self):
+        print("hello 1")
+
+
+class MockTask2(Task):
+    run_every = "1 minutes"
+    timezone = "America/New_York"
+
+    def handle(self):
+        print("hello 2")
+
+
+class TestHandler(TestCase):
+    def test_handler_adds_and_runs_tasks(self):
+        self.handler = TaskHandler(self.application)
+        self.handler.add(MockTask1, MockTask2())
+        self.handler.run()

--- a/tests/features/scheduling/test_scheduling.py
+++ b/tests/features/scheduling/test_scheduling.py
@@ -1,0 +1,160 @@
+import pytest
+import pendulum
+from src.masonite.scheduling import Task
+
+
+class MockTask(Task):
+    run_every = "5 minutes"
+    timezone = "America/New_York"
+
+
+class TestScheduler:
+    def setup_method(self):
+        self.task = MockTask()
+
+    def test_scheduler_should_run(self):
+        assert self.task.run_every == "5 minutes"
+        time = pendulum.now().on(2018, 5, 21).at(22, 5, 5)
+        self.task._date = time
+        assert self.task.should_run(time) == True
+
+        time = pendulum.now().on(2018, 5, 21).at(22, 6, 5)
+        self.task._date = time
+        assert self.task.should_run(time) == False
+
+    def test_scheduler_should_run_every_minute(self):
+        self.task.run_every = "1 minute"
+        time = pendulum.now().on(2018, 5, 21).at(22, 5, 5)
+        self.task._date = time
+        assert self.task.should_run(time) == True
+
+        time = pendulum.now().on(2018, 5, 21).at(22, 6, 5)
+        self.task._date = time
+        assert self.task.should_run(time) == True
+
+    def test_scheduler_should_run_every_2_minutes(self):
+        self.task.run_every = "2 minutes"
+        time = pendulum.now().on(2018, 5, 21).at(14, 56, 5)
+        self.task._date = time
+        assert self.task.should_run(time) == True
+
+        time = pendulum.now().on(2018, 5, 21).at(14, 58, 5)
+        self.task._date = time
+        assert self.task.should_run(time) == True
+
+    def test_scheduler_should_run_every_hour(self):
+        self.task.run_every = "1 hour"
+        time = pendulum.now().on(2018, 5, 21).at(2, 0, 1)
+        self.task._date = time
+        assert self.task.should_run(time) == True
+
+        time = pendulum.now().on(2018, 5, 21).at(3, 0, 1)
+        self.task._date = time
+        assert self.task.should_run(time) == True
+
+        self.task.run_every = "2 hours"
+        time = pendulum.now().on(2018, 5, 21).at(2, 0, 1)
+        self.task._date = time
+        assert self.task.should_run(time) == True
+
+        self.task.run_every = "2 hours"
+        time = pendulum.now().on(2018, 5, 21).at(3, 0, 1)
+        self.task._date = time
+        assert self.task.should_run(time) == False
+
+        time = pendulum.now().on(2018, 5, 21).at(4, 0, 1)
+        self.task._date = time
+        assert self.task.should_run(time) == True
+
+    def test_scheduler_should_run_every_days(self):
+        self.task.run_every = "2 days"
+        time = pendulum.now().on(2018, 5, 21).at(0, 0, 1)
+        self.task._date = time
+        assert self.task.should_run(time) == False
+
+        time = pendulum.now().on(2018, 5, 23).at(0, 0, 1)
+        self.task._date = time
+        assert self.task.should_run(time) == False
+
+        self.task.run_at = "5:30"
+        time = pendulum.now().on(2018, 5, 22).at(5, 30, 0)
+        self.task._date = time
+        assert self.task.should_run(time) == True
+
+        self.task.run_at = "5:35"
+        time = pendulum.now().on(2018, 5, 22).at(5, 30, 0)
+        self.task._date = time
+        assert self.task.should_run(time) == False
+
+    def test_scheduler_should_run_every_months(self):
+        self.task.run_every = "2 months"
+        time = pendulum.now().on(2018, 1, 1).at(0, 0, 1)
+        self.task._date = time
+        assert self.task.should_run(time) == False
+
+        time = pendulum.now().on(2018, 2, 1).at(0, 0, 1)
+        self.task._date = time
+        assert self.task.should_run(time) == True
+
+        time = pendulum.now().on(2018, 2, 1).at(10, 0, 1)
+        self.task._date = time
+        assert self.task.should_run(time) == False
+
+        self.task.run_at = "5:30"
+        time = pendulum.now().on(2018, 2, 1).at(5, 30, 0)
+        self.task._date = time
+        assert self.task.should_run(time) == False
+
+    def test_twice_daily_at_correct_time(self):
+        time = pendulum.now().on(2018, 1, 1).at(1, 20, 5)
+        self.task.run_every = ""
+        self.task.twice_daily = (1, 13)
+        self.task._date = time
+
+        assert self.task.should_run()
+
+        time = pendulum.now().on(2018, 1, 1).at(13, 20, 5)
+        self.task._date = time
+        assert self.task.should_run()
+
+    def test_twice_daily_at_incorrect_time(self):
+        time = pendulum.now().on(2018, 1, 1).at(12, 20, 5)
+        self.task.run_every = ""
+        self.task.twice_daily = (1, 13)
+        self.task._date = time
+
+        assert self.task.should_run() is False
+
+    def test_run_at(self):
+        self.task.run_every = ""
+        self.task.run_at = None
+        self.task.run_at = "13:00"
+
+        time = pendulum.now().on(2018, 1, 1).at(13, 0, 5)
+        self.task._date = time
+
+        self.task.run_at = "13:05"
+
+        time = pendulum.now().on(2018, 1, 1).at(13, 5, 5)
+        self.task._date = time
+
+        assert self.task.should_run() is True
+
+        time = pendulum.now().on(2018, 1, 1).at(13, 6, 5)
+        self.task._date = time
+
+        assert self.task.should_run() is False
+
+    def test_method_calls(self):
+        task = MockTask()
+        task.at("13:00")
+
+        time = pendulum.now().on(2018, 1, 1).at(13, 0, 5)
+        task._date = time
+
+        task = MockTask()
+        task.every_minute()
+
+        time = pendulum.now().on(2018, 5, 21).at(22, 5, 5)
+        task._date = time
+        assert task.should_run(time) == True

--- a/tests/features/scheduling/test_scheduling.py
+++ b/tests/features/scheduling/test_scheduling.py
@@ -151,6 +151,8 @@ class TestScheduler:
         time = pendulum.now().on(2018, 1, 1).at(13, 0, 5)
         task._date = time
 
+        assert task.should_run(time) == True
+
         task = MockTask()
         task.every_minute()
 

--- a/tests/features/scheduling/test_scheduling.py
+++ b/tests/features/scheduling/test_scheduling.py
@@ -127,7 +127,6 @@ class TestScheduler:
 
     def test_run_at(self):
         self.task.run_every = ""
-        self.task.run_at = None
         self.task.run_at = "13:00"
 
         time = pendulum.now().on(2018, 1, 1).at(13, 0, 5)

--- a/tests/integrations/config/providers.py
+++ b/tests/integrations/config/providers.py
@@ -10,6 +10,8 @@ from src.masonite.providers import (
     QueueProvider,
 )
 
+from src.masonite.scheduling.providers import ScheduleProvider
+
 
 PROVIDERS = [
     FrameworkProvider,
@@ -20,4 +22,5 @@ PROVIDERS = [
     MailProvider,
     SessionProvider,
     QueueProvider,
+    ScheduleProvider,
 ]


### PR DESCRIPTION
Merged the Masonite-scheduler package into this codebase. Actually only took literally 5 minutes.

We will abandon that masonite-scheduler repo https://github.com/MasoniteFramework/scheduler when Masonite 4 comes out.

This PR still needs:

- [x] Clean codebase and improve upon from original task scheduling codebase
- [ ] Look at any additional features this could support

It would be cool if we could run a lambda function. Something like this:

```python
self.schedule(lambda: (
    self.application.make('mail').mailable(CronEmail(['joe@masoniteproject.com'])).send()
)).every('3 days')
```

## New Documentation

This PR adds the task scheduling from the masonite-scheduler repo to the core codebase.

This also adds a new Task Handler class (in keeping with the white paper we set out at the beginning of the project)

This handler class is really just an internal class but we can add tasks to it like we do commands and other things:

```python
self.appllication.make('scheduler').add(Task1(), Task2())
```

There is a wrapper around this if you make a service provider:

```python
from masonite.scheduling import CanSchedule

class ConsoleProvider(Provider, CanSchedule):

    def register(self):
         self.schedule(Task1()).daily_at(13,17) # runs daily at 1pm and 5pm
```

Theres a bunch of diff timing methods in the docs and thats really all there is to this PR ...