### PR TITLE
Added Caching Feature

### DIFF
--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -26,7 +26,7 @@ jobs:
         MAIL_USERNAME: ${{ github.secrets.MAIL_USERNAME }}
         MAIL_PASSWORD: ${{ github.secrets.MAIL_PASSWORD }}
       run: |
-        make test
+        make ci
   lint:
     runs-on: ubuntu-latest
     name: Lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 **/*.pyc
 venv
 **/*.DS_Store
+.env.*
 .env
+storage/framework/cache

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ init:
 test:
 	python -m pytest tests
 ci:
-	make test
+	python -m pytest tests -m "not integrations"
 lint:
 	python -m flake8 src/masonite/ --ignore=E501,F401,E203,E128,E402,E731,F821,E712,W503,F811
 format:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integrations: only run integration tests (deselect with '-m "not integations"')

--- a/src/masonite/cache/Cache.py
+++ b/src/masonite/cache/Cache.py
@@ -1,0 +1,60 @@
+class Cache:
+    def __init__(self, application, store_config=None):
+        self.application = application
+        self.drivers = {}
+        self.store_config = store_config or {}
+        self.options = {}
+
+    def add_driver(self, name, driver):
+        self.drivers.update({name: driver})
+
+    def set_configuration(self, config):
+        self.store_config = config
+        return self
+
+    def get_driver(self, name=None):
+        if name is None:
+            return self.drivers[self.store_config.get("default")]
+        return self.drivers[name]
+
+    def get_store_config(self, name=None):
+        print(self.store_config)
+        if name is None or name == "default":
+            return self.store_config.get(self.store_config.get("default"))
+
+        return self.store_config.get(name)
+
+    def get_config_options(self, name=None):
+        if name is None or name == "default":
+            return self.store_config.get(self.store_config.get("default"))
+
+        return self.store_config.get(name)
+
+    def store(self, name="default"):
+        store_config = self.get_config_options(name)
+        driver = self.get_driver(self.get_config_options(name).get("driver"))
+        return driver.set_options(store_config)
+
+    def get(self, *args, **kwargs):
+        pass
+
+    def put(self, *args, **kwargs):
+        pass
+
+    def has(self, *args, **kwargs):
+        pass
+
+    def increment(self, *args, **kwargs):
+        pass
+
+    def decrement(self, *args, **kwargs):
+        pass
+
+    def remember(self, *args, **kwargs):
+        pass
+
+    def forget(self, *args, **kwargs):
+        pass
+
+    def flush(self, *args, **kwargs):
+        pass

--- a/src/masonite/cache/Cache.py
+++ b/src/masonite/cache/Cache.py
@@ -34,27 +34,3 @@ class Cache:
         store_config = self.get_config_options(name)
         driver = self.get_driver(self.get_config_options(name).get("driver"))
         return driver.set_options(store_config)
-
-    def get(self, *args, **kwargs):
-        pass
-
-    def put(self, *args, **kwargs):
-        pass
-
-    def has(self, *args, **kwargs):
-        pass
-
-    def increment(self, *args, **kwargs):
-        pass
-
-    def decrement(self, *args, **kwargs):
-        pass
-
-    def remember(self, *args, **kwargs):
-        pass
-
-    def forget(self, *args, **kwargs):
-        pass
-
-    def flush(self, *args, **kwargs):
-        pass

--- a/src/masonite/cache/__init__.py
+++ b/src/masonite/cache/__init__.py
@@ -1,0 +1,1 @@
+from .Cache import Cache

--- a/src/masonite/cache/drivers/FileDriver.py
+++ b/src/masonite/cache/drivers/FileDriver.py
@@ -21,7 +21,7 @@ class FileDriver:
             return self.get(key)
 
         self.put(key, value)
-        return self.get(key)
+        return value
 
     def get(self, key, default=None, **options):
         if not self.has(key):
@@ -87,7 +87,7 @@ class FileDriver:
 
     def get_expiration_time(self, seconds):
         if seconds is None:
-            seconds = 9999999
+            seconds = 31557600 * 10
 
         return seconds
 

--- a/src/masonite/cache/drivers/FileDriver.py
+++ b/src/masonite/cache/drivers/FileDriver.py
@@ -34,7 +34,7 @@ class FileDriver:
 
             if modified_at.add(seconds=self.get_cache_expiration(value)).is_past():
                 self.forget(key)
-                return None
+                return default
 
             value = self.get_value(value)
 

--- a/src/masonite/cache/drivers/FileDriver.py
+++ b/src/masonite/cache/drivers/FileDriver.py
@@ -16,6 +16,13 @@ class FileDriver:
             make_full_directory(options.get("location"))
         return self
 
+    def add(self, key, value):
+        if self.has(key):
+            return self.get(key)
+
+        self.put(key, value)
+        return self.get(key)
+
     def get(self, key, default=None, **options):
         if not self.has(key):
             return None

--- a/src/masonite/cache/drivers/FileDriver.py
+++ b/src/masonite/cache/drivers/FileDriver.py
@@ -1,0 +1,97 @@
+import os
+from ...utils.filesystem import make_full_directory, modified_date
+from pathlib import Path
+import pendulum
+import json
+import glob
+
+
+class FileDriver:
+    def __init__(self, application):
+        self.application = application
+
+    def set_options(self, options):
+        self.options = options
+        if options.get("location"):
+            make_full_directory(options.get("location"))
+        return self
+
+    def get_modified_at(self, filename):
+        return pendulum.from_timestamp(modified_date(filename))
+
+    def get(self, key, default=None, **options):
+        if not self.has(key):
+            return None
+
+        modified_at = self.get_modified_at(os.path.join(self._get_directory(), key))
+
+        with open(os.path.join(self._get_directory(), key), "r") as f:
+            value = f.read()
+
+            if modified_at.add(seconds=self.get_cache_expiration(value)).is_past():
+                self.forget(key)
+                return None
+
+            value = self.get_value(value)
+
+        return value
+
+    def get_expiration_time(self, seconds):
+        if seconds is None:
+            seconds = 9999999
+
+        return seconds
+
+    def get_value(self, value):
+        value = str(value.split(":", 1)[1])
+        if value.isdigit():
+            return str(value)
+        try:
+            return json.loads(value)
+        except json.decoder.JSONDecodeError:
+            return value
+
+    def get_cache_expiration(self, value):
+        return int(value.split(":", 1)[0])
+
+    def put(self, key, value, seconds=None, **options):
+
+        time = self.get_expiration_time(seconds)
+
+        if isinstance(value, (dict,)):
+            value = json.dumps(value)
+
+        with open(os.path.join(self._get_directory(), key), "w") as f:
+            f.write(f"{time}:{value}")
+
+    def has(self, key):
+        return Path(os.path.join(self._get_directory(), key)).exists()
+
+    def increment(self, key, amount=1):
+        return self.put(key, str(int(self.get(key)) + amount))
+
+    def decrement(self, key, amount=1):
+        return self.put(key, str(int(self.get(key)) - amount))
+
+    def remember(self, key, callable):
+        value = self.get(key)
+
+        if value:
+            return value
+
+        callable(self)
+
+    def forget(self, key):
+        try:
+            os.remove(os.path.join(self._get_directory(), key))
+            return True
+        except FileNotFoundError:
+            return False
+
+    def flush(self):
+        files = glob.glob(f"{self._get_directory()}/*")
+        for f in files:
+            os.remove(f)
+
+    def _get_directory(self):
+        return self.options.get("location")

--- a/src/masonite/cache/drivers/MemcacheDriver.py
+++ b/src/masonite/cache/drivers/MemcacheDriver.py
@@ -1,7 +1,3 @@
-import os
-from ...utils.filesystem import make_full_directory, modified_date
-from pathlib import Path
-import pendulum
 import json
 
 

--- a/src/masonite/cache/drivers/MemcacheDriver.py
+++ b/src/masonite/cache/drivers/MemcacheDriver.py
@@ -33,7 +33,7 @@ class MemcacheDriver:
 
     def get(self, key, default=None, **options):
         if not self.has(key):
-            return None
+            return default
 
         return self.get_value(
             self.get_connection().get(f"{self.get_name()}_cache_{key}")

--- a/src/masonite/cache/drivers/MemcacheDriver.py
+++ b/src/masonite/cache/drivers/MemcacheDriver.py
@@ -4,11 +4,10 @@ import json
 class MemcacheDriver:
     def __init__(self, application):
         self.application = application
+        self.connection = None
 
     def set_options(self, options):
         self.options = options
-        if options.get("location"):
-            make_full_directory(options.get("location"))
         return self
 
     def get_connection(self):
@@ -19,10 +18,17 @@ class MemcacheDriver:
                 "Could not find the 'pymemcache' library. Run 'pip install pymemcache' to fix this."
             )
 
+        if self.connection:
+            return self.connection
+
         if self.options.get("port"):
-            return Client(f"{self.options.get('host')}:{self.options.get('port')}")
+            self.connection = Client(
+                f"{self.options.get('host')}:{self.options.get('port')}"
+            )
         else:
-            return Client(f"{self.options.get('host')}")
+            self.connection = Client(f"{self.options.get('host')}")
+
+        return self.connection
 
     def add(self, key, value):
         if self.has(key):

--- a/src/masonite/cache/drivers/MemcacheDriver.py
+++ b/src/masonite/cache/drivers/MemcacheDriver.py
@@ -69,11 +69,7 @@ class MemcacheDriver:
         callable(self)
 
     def forget(self, key):
-        try:
-            self.get_connection().delete(f"{self.get_name()}_cache_{key}")
-            return True
-        except FileNotFoundError:
-            return False
+        return self.get_connection().delete(f"{self.get_name()}_cache_{key}")
 
     def flush(self):
         return self.get_connection().flush_all()

--- a/src/masonite/cache/drivers/MemcacheDriver.py
+++ b/src/masonite/cache/drivers/MemcacheDriver.py
@@ -18,15 +18,13 @@ class MemcacheDriver:
                 "Could not find the 'pymemcache' library. Run 'pip install pymemcache' to fix this."
             )
 
-        if self.connection:
-            return self.connection
-
-        if self.options.get("port"):
-            self.connection = Client(
-                f"{self.options.get('host')}:{self.options.get('port')}"
-            )
-        else:
-            self.connection = Client(f"{self.options.get('host')}")
+        if not self.connection:
+            if str(self.options.get("port")) != "0":
+                self.connection = Client(
+                    f"{self.options.get('host')}:{self.options.get('port')}"
+                )
+            else:
+                self.connection = Client(f"{self.options.get('host')}")
 
         return self.connection
 

--- a/src/masonite/cache/drivers/MemcacheDriver.py
+++ b/src/masonite/cache/drivers/MemcacheDriver.py
@@ -1,0 +1,94 @@
+import os
+from ...utils.filesystem import make_full_directory, modified_date
+from pathlib import Path
+import pendulum
+import json
+
+
+class MemcacheDriver:
+    def __init__(self, application):
+        self.application = application
+
+    def set_options(self, options):
+        self.options = options
+        if options.get("location"):
+            make_full_directory(options.get("location"))
+        return self
+
+    def get_connection(self):
+        try:
+            from pymemcache.client.base import Client
+        except ImportError:
+            raise ModuleNotFoundError(
+                "Could not find the 'pymemcache' library. Run 'pip install pymemcache' to fix this."
+            )
+
+        if self.options.get("port"):
+            return Client(f"{self.options.get('host')}:{self.options.get('port')}")
+        else:
+            return Client(f"{self.options.get('host')}")
+
+    def add(self, key, value):
+        if self.has(key):
+            return self.get(key)
+
+        self.put(key, value)
+        return value
+
+    def get(self, key, default=None, **options):
+        if not self.has(key):
+            return None
+
+        return self.get_value(
+            self.get_connection().get(f"{self.get_name()}_cache_{key}")
+        )
+
+    def put(self, key, value, seconds=0, **options):
+        if isinstance(value, (dict, list)):
+            value = json.dumps(value)
+
+        return self.get_connection().set(
+            f"{self.get_name()}_cache_{key}", value, expire=seconds
+        )
+
+    def has(self, key):
+        return self.get_connection().get(f"{self.get_name()}_cache_{key}")
+
+    def increment(self, key, amount=1):
+        return self.put(key, str(int(self.get(key)) + amount))
+
+    def decrement(self, key, amount=1):
+        return self.put(key, str(int(self.get(key)) - amount))
+
+    def remember(self, key, callable):
+        value = self.get(key)
+
+        if value:
+            return value
+
+        callable(self)
+
+    def forget(self, key):
+        try:
+            self.get_connection().delete(f"{self.get_name()}_cache_{key}")
+            return True
+        except FileNotFoundError:
+            return False
+
+    def flush(self):
+        return self.get_connection().flush_all()
+
+    def get_name(self):
+        return self.options.get("name")
+
+    def get_value(self, value):
+        if isinstance(value, bytes):
+            value = value.decode("utf-8")
+
+        value = str(value)
+        if value.isdigit():
+            return str(value)
+        try:
+            return json.loads(value)
+        except json.decoder.JSONDecodeError:
+            return value

--- a/src/masonite/cache/drivers/RedisDriver.py
+++ b/src/masonite/cache/drivers/RedisDriver.py
@@ -71,11 +71,7 @@ class RedisDriver:
         callable(self)
 
     def forget(self, key):
-        try:
-            self.get_connection().delete(f"{self.get_name()}_cache_{key}")
-            return True
-        except FileNotFoundError:
-            return False
+        return self.get_connection().delete(f"{self.get_name()}_cache_{key}")
 
     def flush(self):
         return self.get_connection().flushall()
@@ -85,7 +81,7 @@ class RedisDriver:
 
     def get_expiration_time(self, seconds):
         if seconds is None:
-            seconds = 9999999
+            seconds = 31557600 * 10
 
         return seconds
 

--- a/src/masonite/cache/drivers/RedisDriver.py
+++ b/src/masonite/cache/drivers/RedisDriver.py
@@ -31,6 +31,13 @@ class RedisDriver:
             decode_responses=True,
         )
 
+    def add(self, key, value):
+        if self.has(key):
+            return self.get(key)
+
+        self.put(key, value)
+        return value
+
     def get(self, key, default=None, **options):
         if not self.has(key):
             return None

--- a/src/masonite/cache/drivers/RedisDriver.py
+++ b/src/masonite/cache/drivers/RedisDriver.py
@@ -33,7 +33,7 @@ class RedisDriver:
 
     def get(self, key, default=None, **options):
         if not self.has(key):
-            return None
+            return default
         return self.get_value(
             self.get_connection().get(f"{self.get_name()}_cache_{key}")
         )

--- a/src/masonite/cache/drivers/RedisDriver.py
+++ b/src/masonite/cache/drivers/RedisDriver.py
@@ -1,9 +1,4 @@
-import os
-from ...utils.filesystem import make_full_directory, modified_date
-from pathlib import Path
-import pendulum
 import json
-import glob
 
 
 class RedisDriver:
@@ -12,8 +7,6 @@ class RedisDriver:
 
     def set_options(self, options):
         self.options = options
-        if options.get("location"):
-            make_full_directory(options.get("location"))
         return self
 
     def get_connection(self):

--- a/src/masonite/cache/drivers/RedisDriver.py
+++ b/src/masonite/cache/drivers/RedisDriver.py
@@ -4,6 +4,7 @@ import json
 class RedisDriver:
     def __init__(self, application):
         self.application = application
+        self.connection = None
 
     def set_options(self, options):
         self.options = options
@@ -17,12 +18,15 @@ class RedisDriver:
                 "Could not find the 'redis' library. Run 'pip install redis' to fix this."
             )
 
-        return redis.StrictRedis(
-            host=self.options.get("host"),
-            port=self.options.get("port"),
-            password=self.options.get("password"),
-            decode_responses=True,
-        )
+        if not self.connection:
+            self.connection = redis.StrictRedis(
+                host=self.options.get("host"),
+                port=self.options.get("port"),
+                password=self.options.get("password"),
+                decode_responses=True,
+            )
+
+        return self.connection
 
     def add(self, key, value):
         if self.has(key):

--- a/src/masonite/cache/drivers/__init__.py
+++ b/src/masonite/cache/drivers/__init__.py
@@ -1,0 +1,1 @@
+from .FileDriver import FileDriver

--- a/src/masonite/cache/drivers/__init__.py
+++ b/src/masonite/cache/drivers/__init__.py
@@ -1,1 +1,2 @@
 from .FileDriver import FileDriver
+from .RedisDriver import RedisDriver

--- a/src/masonite/cache/drivers/__init__.py
+++ b/src/masonite/cache/drivers/__init__.py
@@ -1,2 +1,3 @@
 from .FileDriver import FileDriver
 from .RedisDriver import RedisDriver
+from .MemcacheDriver import MemcacheDriver

--- a/src/masonite/foundation/Kernel.py
+++ b/src/masonite/foundation/Kernel.py
@@ -39,6 +39,7 @@ class Kernel:
         self.application.bind("config.session", "tests.integrations.config.session")
         self.application.bind("config.queue", "tests.integrations.config.queue")
         self.application.bind("config.database", "tests.integrations.config.database")
+        self.application.bind("config.cache", "tests.integrations.config.cache")
 
     def register_controllers(self):
         self.application.bind("controller.location", "tests.integrations.controllers")

--- a/src/masonite/providers/CacheProvider.py
+++ b/src/masonite/providers/CacheProvider.py
@@ -1,6 +1,6 @@
 from .Provider import Provider
 from ..cache import Cache
-from ..cache.drivers import FileDriver
+from ..cache.drivers import FileDriver, RedisDriver
 from ..utils.structures import load
 
 
@@ -13,6 +13,7 @@ class CacheProvider(Provider):
             load(self.application.make("config.cache")).STORES
         )
         cache.add_driver("file", FileDriver(self.application))
+        cache.add_driver("redis", RedisDriver(self.application))
         self.application.bind("cache", cache)
 
     def boot(self):

--- a/src/masonite/providers/CacheProvider.py
+++ b/src/masonite/providers/CacheProvider.py
@@ -1,0 +1,19 @@
+from .Provider import Provider
+from ..cache import Cache
+from ..cache.drivers import FileDriver
+from ..utils.structures import load
+
+
+class CacheProvider(Provider):
+    def __init__(self, application):
+        self.application = application
+
+    def register(self):
+        cache = Cache(self.application).set_configuration(
+            load(self.application.make("config.cache")).STORES
+        )
+        cache.add_driver("file", FileDriver(self.application))
+        self.application.bind("cache", cache)
+
+    def boot(self):
+        pass

--- a/src/masonite/providers/CacheProvider.py
+++ b/src/masonite/providers/CacheProvider.py
@@ -1,6 +1,6 @@
 from .Provider import Provider
 from ..cache import Cache
-from ..cache.drivers import FileDriver, RedisDriver
+from ..cache.drivers import FileDriver, RedisDriver, MemcacheDriver
 from ..utils.structures import load
 
 
@@ -14,6 +14,7 @@ class CacheProvider(Provider):
         )
         cache.add_driver("file", FileDriver(self.application))
         cache.add_driver("redis", RedisDriver(self.application))
+        cache.add_driver("memcache", MemcacheDriver(self.application))
         self.application.bind("cache", cache)
 
     def boot(self):

--- a/src/masonite/providers/__init__.py
+++ b/src/masonite/providers/__init__.py
@@ -8,3 +8,4 @@ from .Provider import Provider
 from .MailProvider import MailProvider
 from .SessionProvider import SessionProvider
 from .QueueProvider import QueueProvider
+from .CacheProvider import CacheProvider

--- a/src/masonite/utils/filesystem.py
+++ b/src/masonite/utils/filesystem.py
@@ -3,6 +3,7 @@ import platform
 
 
 def make_directory(directory):
+    """Create a directory at the given path for a file if it does not exist"""
     if not os.path.isfile(directory):
         if not os.path.exists(os.path.dirname(directory)):
             # Create the path to the model if it does not exist
@@ -14,6 +15,7 @@ def make_directory(directory):
 
 
 def make_full_directory(directory):
+    """Create all directories to the given path if they do not exist"""
     if not os.path.isfile(directory):
         if not os.path.exists(directory):
             # Create the path to the model if it does not exist
@@ -25,10 +27,8 @@ def make_full_directory(directory):
 
 
 def creation_date(path_to_file):
-    """
-    Try to get the date that a file was created, falling back to when it was
+    """Try to get the date that a file was created, falling back to when it was
     last modified if that isn't possible.
-    See http://stackoverflow.com/a/39501288/1709587 for explanation.
     """
     if platform.system() == "Windows":
         return os.path.getctime(path_to_file)

--- a/src/masonite/utils/filesystem.py
+++ b/src/masonite/utils/filesystem.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 
 def make_directory(directory):
@@ -10,3 +11,45 @@ def make_directory(directory):
         return True
 
     return False
+
+
+def make_full_directory(directory):
+    if not os.path.isfile(directory):
+        if not os.path.exists(directory):
+            # Create the path to the model if it does not exist
+            os.makedirs(directory)
+
+        return True
+
+    return False
+
+
+def creation_date(path_to_file):
+    """
+    Try to get the date that a file was created, falling back to when it was
+    last modified if that isn't possible.
+    See http://stackoverflow.com/a/39501288/1709587 for explanation.
+    """
+    if platform.system() == "Windows":
+        return os.path.getctime(path_to_file)
+    else:
+        stat = os.stat(path_to_file)
+        try:
+            return stat.st_birthtime
+        except AttributeError:
+            # We're probably on Linux. No easy way to get creation dates here,
+            # so we'll settle for when its content was last modified.
+            return stat.st_mtime
+
+
+def modified_date(path_to_file):
+    if platform.system() == "Windows":
+        return os.path.getmtime(path_to_file)
+    else:
+        stat = os.stat(path_to_file)
+        try:
+            return stat.st_mtime
+        except AttributeError:
+            # We're probably on Linux. No easy way to get creation dates here,
+            # so we'll settle for when its content was last modified.
+            return 0

--- a/tests/features/cache/test_file_cache.py
+++ b/tests/features/cache/test_file_cache.py
@@ -3,7 +3,7 @@ import os
 import time
 
 
-class TestMailable(TestCase):
+class TestFileCache(TestCase):
     def setUp(self):
         super().setUp()
         self.application.make("cache")

--- a/tests/features/cache/test_file_cache.py
+++ b/tests/features/cache/test_file_cache.py
@@ -1,0 +1,58 @@
+from tests import TestCase
+import os
+import time
+
+
+class TestMailable(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.application.make("cache")
+        self.driver = self.application.make("cache").store()
+
+    def test_can_get_file_driver(self):
+        self.driver.put("key", "value")
+        self.assertEqual(self.driver.get("key"), "value")
+        self.assertTrue(self.driver.has("key"), "value")
+
+    def test_can_increment(self):
+        self.driver.put("count", "1")
+        self.assertEqual(self.driver.get("count"), "1")
+        self.driver.increment("count")
+        self.assertEqual(self.driver.get("count"), "2")
+        self.driver.decrement("count")
+        self.assertEqual(self.driver.get("count"), "1")
+
+    def test_will_not_get_expired(self):
+        self.driver.put("expire", "1", 1)
+
+        time.sleep(2)
+        self.assertEqual(self.driver.get("expire"), None)
+
+    def test_will_get_not_yet_expired(self):
+        self.driver.put("expire", "1", 20)
+        self.assertEqual(self.driver.get("expire"), "1")
+
+    def test_forget(self):
+        self.driver.put("forget", "1")
+        self.assertEqual(self.driver.get("forget"), "1")
+        self.driver.forget("forget")
+        self.assertEqual(self.driver.get("forget"), None)
+
+    def test_remember(self):
+        self.driver.remember("remember", lambda cache: (cache.put("remember", "1", 10)))
+        self.assertEqual(self.driver.get("remember"), "1")
+
+    def test_remember_datatypes(self):
+        self.driver.remember(
+            "dic", lambda cache: (cache.put("dic", {"id": 1, "name": "Joe"}, 10))
+        )
+        self.assertIsInstance(self.driver.get("dic"), dict)
+        self.driver.remember("list", lambda cache: (cache.put("list", [1, 2, 3], 10)))
+        self.assertIsInstance(self.driver.get("list"), list)
+
+    def test_flush(self):
+        self.driver.remember(
+            "dic", lambda cache: (cache.put("dic", {"id": 1, "name": "Joe"}, 10))
+        )
+        self.driver.flush()
+        self.assertIsNone(self.driver.get("dic"))

--- a/tests/features/cache/test_file_cache.py
+++ b/tests/features/cache/test_file_cache.py
@@ -14,6 +14,9 @@ class TestMailable(TestCase):
         self.assertEqual(self.driver.get("key"), "value")
         self.assertTrue(self.driver.has("key"), "value")
 
+    def test_can_add_file_driver(self):
+        self.assertEqual(self.driver.add("add_key", "value"), "value")
+
     def test_can_increment(self):
         self.driver.put("count", "1")
         self.assertEqual(self.driver.get("count"), "1")

--- a/tests/features/cache/test_memcache_cache.py
+++ b/tests/features/cache/test_memcache_cache.py
@@ -5,11 +5,11 @@ import pytest
 
 
 @pytest.mark.integrations
-class TestRedisCache(TestCase):
+class TestMemcacheCache(TestCase):
     def setUp(self):
         super().setUp()
         self.application.make("cache")
-        self.driver = self.application.make("cache").store("redis")
+        self.driver = self.application.make("cache").store("memcache")
 
     def test_can_add_file_driver(self):
         self.assertEqual(self.driver.add("add_key", "value"), "value")

--- a/tests/features/cache/test_redis_cache.py
+++ b/tests/features/cache/test_redis_cache.py
@@ -1,8 +1,10 @@
 from tests import TestCase
 import os
 import time
+import pytest
 
 
+@pytest.mark.integrations
 class TestMailable(TestCase):
     def setUp(self):
         super().setUp()

--- a/tests/features/cache/test_redis_cache.py
+++ b/tests/features/cache/test_redis_cache.py
@@ -9,6 +9,9 @@ class TestMailable(TestCase):
         self.application.make("cache")
         self.driver = self.application.make("cache").store("redis")
 
+    def test_can_add_file_driver(self):
+        self.assertEqual(self.driver.add("add_key", "value"), "value")
+
     def test_can_get_driver(self):
         self.driver.put("key", "value")
         self.assertEqual(self.driver.get("key"), "value")

--- a/tests/features/cache/test_redis_cache.py
+++ b/tests/features/cache/test_redis_cache.py
@@ -1,0 +1,58 @@
+from tests import TestCase
+import os
+import time
+
+
+class TestMailable(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.application.make("cache")
+        self.driver = self.application.make("cache").store("redis")
+
+    def test_can_get_driver(self):
+        self.driver.put("key", "value")
+        self.assertEqual(self.driver.get("key"), "value")
+        self.assertTrue(self.driver.has("key"), "value")
+
+    def test_can_increment(self):
+        self.driver.put("count", "1")
+        self.assertEqual(self.driver.get("count"), "1")
+        self.driver.increment("count")
+        self.assertEqual(self.driver.get("count"), "2")
+        self.driver.decrement("count")
+        self.assertEqual(self.driver.get("count"), "1")
+
+    def test_will_not_get_expired(self):
+        self.driver.put("expire", "1", 1)
+
+        time.sleep(2)
+        self.assertEqual(self.driver.get("expire"), None)
+
+    def test_will_get_not_yet_expired(self):
+        self.driver.put("expire", "1", 20)
+        self.assertEqual(self.driver.get("expire"), "1")
+
+    def test_forget(self):
+        self.driver.put("forget", "1")
+        self.assertEqual(self.driver.get("forget"), "1")
+        self.driver.forget("forget")
+        self.assertEqual(self.driver.get("forget"), None)
+
+    def test_remember(self):
+        self.driver.remember("remember", lambda cache: (cache.put("remember", "1", 10)))
+        self.assertEqual(self.driver.get("remember"), "1")
+
+    def test_remember_datatypes(self):
+        self.driver.remember(
+            "dic", lambda cache: (cache.put("dic", {"id": 1, "name": "Joe"}, 10))
+        )
+        self.assertIsInstance(self.driver.get("dic"), dict)
+        self.driver.remember("list", lambda cache: (cache.put("list", [1, 2, 3], 10)))
+        self.assertIsInstance(self.driver.get("list"), list)
+
+    def test_flush(self):
+        self.driver.remember(
+            "dic", lambda cache: (cache.put("dic", {"id": 1, "name": "Joe"}, 10))
+        )
+        self.driver.flush()
+        self.assertIsNone(self.driver.get("dic"))

--- a/tests/integrations/config/cache.py
+++ b/tests/integrations/config/cache.py
@@ -1,0 +1,10 @@
+"""Cache Config"""
+
+STORES = {
+    "default": "local",
+    "local": {
+        "driver": "file",
+        "location": "storage/framework/cache"
+        #
+    },
+}

--- a/tests/integrations/config/cache.py
+++ b/tests/integrations/config/cache.py
@@ -14,4 +14,11 @@ STORES = {
         "password": "",
         "name": "masonite4",
     },
+    "memcache": {
+        "driver": "memcache",
+        "host": "127.0.0.1",
+        "port": "11211",
+        "password": "",
+        "name": "masonite4",
+    },
 }

--- a/tests/integrations/config/cache.py
+++ b/tests/integrations/config/cache.py
@@ -7,4 +7,11 @@ STORES = {
         "location": "storage/framework/cache"
         #
     },
+    "redis": {
+        "driver": "redis",
+        "host": "127.0.0.1",
+        "port": "6379",
+        "password": "",
+        "name": "masonite4",
+    },
 }

--- a/tests/integrations/config/providers.py
+++ b/tests/integrations/config/providers.py
@@ -8,6 +8,7 @@ from src.masonite.providers import (
     MailProvider,
     SessionProvider,
     QueueProvider,
+    CacheProvider,
 )
 
 from src.masonite.scheduling.providers import ScheduleProvider
@@ -21,6 +22,7 @@ PROVIDERS = [
     ExceptionProvider,
     MailProvider,
     SessionProvider,
+    CacheProvider,
     QueueProvider,
     ScheduleProvider,
 ]


### PR DESCRIPTION
Closes #23 

This adds a caching feature. This has multiple "Stores" which are like database connections. To add something to the default store you would do something like this:

```python
def show(self, cache: Cache):
    cache.store().put(key, value, seconds)
```

^^ Not 100% sold on this as it seems like a needless call but one of the few downsides to this structure is that managers are singletons now which means if you switch a driver in 1 part of the request like in a middleware, it will remain switched forever until you switch it back .. With the above approach at least we create a new driver class when this is called so we get around it and its not THAT big of a deal ..

To use a specific store:

```python
def show(self, cache: Cache):
    cache.store('sessions').put(key, value, seconds)
```

### Todo:

- [x] `redis` driver. (honestly did not know we had this 😓 )
- [x] `memcache` driver
- [x] `add` method (get or create method)