### PR TITLE
Feature/26

### DIFF
--- a/src/masonite/auth/guards/WebGuard.py
+++ b/src/masonite/auth/guards/WebGuard.py
@@ -24,10 +24,7 @@ class WebGuard:
         """
         token = self.application.make("request").cookie("token")
         if token and self.model:
-            return (
-                self.model.where("remember_token", token).first()
-                or False
-            )
+            return self.model.where("remember_token", token).first() or False
 
         return False
 

--- a/src/masonite/events/Event.py
+++ b/src/masonite/events/Event.py
@@ -10,109 +10,80 @@ class Event:
             application - The Masonite application class
         """
         self.application = application
-        self.listeners = {}
-        self._fired_events = {}
-        self._arguments = {}
+        self.events = {}
 
-    def event(self, event):
-        """Starts the event observer
-        Arguments:
-            event {string|object}
-        """
+    def get_events(self):
+        return self.events
 
-        self.listen(event, [])
+    def listen(self, event, listeners):
+        if event in self.events:
+            self.events[event] += listeners
+        else:
+            self.events.update({event: listeners})
 
-    def listen(self, event, listeners=[]):
-        """Add a listener to an event.
-        Arguments:
-            event {string|object} -- [description]
-        Keyword Arguments:
-            listeners {list} -- A list of listner classes that should listen to specific events (default: {[]})
-        Returns:
-            self
-        """
-
-        if event in self.listeners:
-            self.listeners[event] += listeners
-            return self
-
-        self.listeners.update({event: listeners})
         return self
 
-    def fire(self, events, **keywords):
-        """Fire an event which fires all the listeners attached to that event.
-        Arguments:
-            events {string|object} -- The event to fire
-        """
-
-        fired_listeners = {}
-        if isinstance(events, str) and "*" in events:
-            for event_action, listener_events in self.listeners.items():
-                fired_listeners.update({event_action: []})
-                for listener in listener_events:
-                    search = events.split("*")
-                    if (
-                        events.endswith("*")
-                        and event_action.startswith(search[0])
-                        or events.startswith("*")
-                        and event_action.endswith(search[1])
-                        or event_action.startswith(search[0])
-                        and event_action.endswith(search[1])
-                    ):
-                        event = self.container.resolve(listener)
-                        fired_listeners[event_action].append(event)
-                        for key, value in keywords.items():
-                            event._arguments.update({key: value})
-                        self.container.resolve(event.handle)
+    def fire(self, event, payload=None):
+        if isinstance(event, str):
+            if event in self.events:
+                for listener in self.events.get(event):
+                    listener().handle(payload)
+            collected_events = self.collect_events(event)
+            return collected_events
         else:
-            fired_listeners.update({events: []})
-            for event in self.listeners[events]:
-                event = self.container.resolve(event)
-                fired_listeners[events].append(event)
-                for key, value in keywords.items():
-                    event._arguments.update({key: value})
-                self.container.resolve(event.handle)
+            for event, listeners in self.events.items():
+                for listener in listeners:
+                    listener().handle(payload)
 
-        self._fired_events = self.clear_blank_fired_events(fired_listeners)
+    def collect_events(self, fired_event):
+        collected_events = []
+        for stored_event in self.events.keys():
 
-    def clear_blank_fired_events(self, fired_listeners):
-        """Just an internal cleaner helper that cleans any the listeners for any fired events.
-        This will, in effect, return the fired events
-        Arguments:
-            fired_listeners {dict} -- dictionary of event and listeners
-        Returns:
-            dict -- returns a dictionary of fired events
-        """
+            if not isinstance(stored_event, str):
+                continue
 
-        new_dictionary = {}
-        for event, listeners in fired_listeners.items():
-            if listeners:
-                new_dictionary.update({event: listeners})
+            if stored_event == fired_event:
+                collected_events.append(fired_event)
 
-        return new_dictionary
+            elif stored_event.endswith("*") and fired_event.startswith(
+                stored_event.replace("*", "")
+            ):
+                collected_events.append(stored_event)
 
-    def subscribe(self, *listeners):
-        """Subscribe a specific listener object to the events system
-        Raises:
-            InvalidSubscriptionType -- raises when the subscribe attribute on the listener object is not a class.
-        """
+            elif stored_event.startswith("*") and fired_event.endswith(
+                stored_event.replace("*", "")
+            ):
+                collected_events.append(stored_event)
 
-        for listener in listeners:
-            if not isinstance(listener.subscribe, list):
-                raise InvalidSubscriptionType(
-                    "'subscribe' attribute on {0} class must be a list".format(
-                        listener.__name__
-                    )
-                )
-            for action in listener.subscribe:
-                self.listen(action, [listener])
+            elif "*" in stored_event:
+                starts, end = stored_event.split("*")
+                if fired_event.startswith(starts) and fired_event.endswith(end):
+                    collected_events.append(stored_event)
 
-    def argument(self, argument):
-        """Takes the argument and eventually stores the argument on the event class
-        Arguments:
-            argument {string|obj|list|dict} -- Any data type that can be a class attribute
-        Returns:
-            dict
-        """
+        return collected_events
 
-        return self._arguments[argument]
+    # def subscribe(self, *listeners):
+    #     """Subscribe a specific listener object to the events system
+    #     Raises:
+    #         InvalidSubscriptionType -- raises when the subscribe attribute on the listener object is not a class.
+    #     """
+
+    #     for listener in listeners:
+    #         if not isinstance(listener.subscribe, list):
+    #             raise InvalidSubscriptionType(
+    #                 "'subscribe' attribute on {0} class must be a list".format(
+    #                     listener.__name__
+    #                 )
+    #             )
+    #         for action in listener.subscribe:
+    #             self.listen(action, [listener])
+
+    # def argument(self, argument):
+    #     """Takes the argument and eventually stores the argument on the event class
+    #     Arguments:
+    #         argument {string|obj|list|dict} -- Any data type that can be a class attribute
+    #     Returns:
+    #         dict
+    #     """
+
+    #     return self._arguments[argument]

--- a/src/masonite/events/Event.py
+++ b/src/masonite/events/Event.py
@@ -16,6 +16,10 @@ class Event:
         return self.events
 
     def listen(self, event, listeners):
+
+        if not isinstance(listeners, list):
+            listeners = [listeners]
+
         if event in self.events:
             self.events[event] += listeners
         else:

--- a/src/masonite/events/Event.py
+++ b/src/masonite/events/Event.py
@@ -1,0 +1,118 @@
+""" Event Module """
+
+from .exceptions import InvalidSubscriptionType
+
+
+class Event:
+    def __init__(self, application):
+        """Event contructor
+        Arguments:
+            application - The Masonite application class
+        """
+        self.application = application
+        self.listeners = {}
+        self._fired_events = {}
+        self._arguments = {}
+
+    def event(self, event):
+        """Starts the event observer
+        Arguments:
+            event {string|object}
+        """
+
+        self.listen(event, [])
+
+    def listen(self, event, listeners=[]):
+        """Add a listener to an event.
+        Arguments:
+            event {string|object} -- [description]
+        Keyword Arguments:
+            listeners {list} -- A list of listner classes that should listen to specific events (default: {[]})
+        Returns:
+            self
+        """
+
+        if event in self.listeners:
+            self.listeners[event] += listeners
+            return self
+
+        self.listeners.update({event: listeners})
+        return self
+
+    def fire(self, events, **keywords):
+        """Fire an event which fires all the listeners attached to that event.
+        Arguments:
+            events {string|object} -- The event to fire
+        """
+
+        fired_listeners = {}
+        if isinstance(events, str) and "*" in events:
+            for event_action, listener_events in self.listeners.items():
+                fired_listeners.update({event_action: []})
+                for listener in listener_events:
+                    search = events.split("*")
+                    if (
+                        events.endswith("*")
+                        and event_action.startswith(search[0])
+                        or events.startswith("*")
+                        and event_action.endswith(search[1])
+                        or event_action.startswith(search[0])
+                        and event_action.endswith(search[1])
+                    ):
+                        event = self.container.resolve(listener)
+                        fired_listeners[event_action].append(event)
+                        for key, value in keywords.items():
+                            event._arguments.update({key: value})
+                        self.container.resolve(event.handle)
+        else:
+            fired_listeners.update({events: []})
+            for event in self.listeners[events]:
+                event = self.container.resolve(event)
+                fired_listeners[events].append(event)
+                for key, value in keywords.items():
+                    event._arguments.update({key: value})
+                self.container.resolve(event.handle)
+
+        self._fired_events = self.clear_blank_fired_events(fired_listeners)
+
+    def clear_blank_fired_events(self, fired_listeners):
+        """Just an internal cleaner helper that cleans any the listeners for any fired events.
+        This will, in effect, return the fired events
+        Arguments:
+            fired_listeners {dict} -- dictionary of event and listeners
+        Returns:
+            dict -- returns a dictionary of fired events
+        """
+
+        new_dictionary = {}
+        for event, listeners in fired_listeners.items():
+            if listeners:
+                new_dictionary.update({event: listeners})
+
+        return new_dictionary
+
+    def subscribe(self, *listeners):
+        """Subscribe a specific listener object to the events system
+        Raises:
+            InvalidSubscriptionType -- raises when the subscribe attribute on the listener object is not a class.
+        """
+
+        for listener in listeners:
+            if not isinstance(listener.subscribe, list):
+                raise InvalidSubscriptionType(
+                    "'subscribe' attribute on {0} class must be a list".format(
+                        listener.__name__
+                    )
+                )
+            for action in listener.subscribe:
+                self.listen(action, [listener])
+
+    def argument(self, argument):
+        """Takes the argument and eventually stores the argument on the event class
+        Arguments:
+            argument {string|obj|list|dict} -- Any data type that can be a class attribute
+        Returns:
+            dict
+        """
+
+        return self._arguments[argument]

--- a/src/masonite/events/Event.py
+++ b/src/masonite/events/Event.py
@@ -72,28 +72,10 @@ class Event:
 
         return collected_events
 
-    # def subscribe(self, *listeners):
-    #     """Subscribe a specific listener object to the events system
-    #     Raises:
-    #         InvalidSubscriptionType -- raises when the subscribe attribute on the listener object is not a class.
-    #     """
-
-    #     for listener in listeners:
-    #         if not isinstance(listener.subscribe, list):
-    #             raise InvalidSubscriptionType(
-    #                 "'subscribe' attribute on {0} class must be a list".format(
-    #                     listener.__name__
-    #                 )
-    #             )
-    #         for action in listener.subscribe:
-    #             self.listen(action, [listener])
-
-    # def argument(self, argument):
-    #     """Takes the argument and eventually stores the argument on the event class
-    #     Arguments:
-    #         argument {string|obj|list|dict} -- Any data type that can be a class attribute
-    #     Returns:
-    #         dict
-    #     """
-
-    #     return self._arguments[argument]
+    def subscribe(self, *listeners):
+        """Subscribe a specific listener object to the events system
+        Raises:
+            InvalidSubscriptionType -- raises when the subscribe attribute on the listener object is not a class.
+        """
+        for listener in listeners:
+            listener.subscribe(self)

--- a/src/masonite/events/Listener.py
+++ b/src/masonite/events/Listener.py
@@ -1,0 +1,2 @@
+class Listener:
+    pass

--- a/src/masonite/events/__init__.py
+++ b/src/masonite/events/__init__.py
@@ -1,0 +1,1 @@
+from .Event import Event

--- a/src/masonite/events/exceptions.py
+++ b/src/masonite/events/exceptions.py
@@ -1,2 +1,0 @@
-class InvalidSubscriptionType(Exception):
-    pass

--- a/src/masonite/events/exceptions.py
+++ b/src/masonite/events/exceptions.py
@@ -1,0 +1,2 @@
+class InvalidSubscriptionType(Exception):
+    pass

--- a/src/masonite/events/providers/EventProvider.py
+++ b/src/masonite/events/providers/EventProvider.py
@@ -1,0 +1,15 @@
+from ...providers import Provider
+from ..Event import Event
+from ...utils.structures import config, load
+
+
+class EventProvider(Provider):
+    def __init__(self, application):
+        self.application = application
+
+    def register(self):
+        event = Event(self.application)
+        self.application.bind("event", event)
+
+    def boot(self):
+        pass

--- a/src/masonite/events/providers/__init__.py
+++ b/src/masonite/events/providers/__init__.py
@@ -1,0 +1,1 @@
+from .EventProvider import EventProvider

--- a/src/masonite/providers/__init__.py
+++ b/src/masonite/providers/__init__.py
@@ -9,3 +9,4 @@ from .MailProvider import MailProvider
 from .SessionProvider import SessionProvider
 from .QueueProvider import QueueProvider
 from .CacheProvider import CacheProvider
+from ..events.providers import EventProvider

--- a/src/masonite/utils/helpers.py
+++ b/src/masonite/utils/helpers.py
@@ -532,6 +532,7 @@ def password(password_string):
         string -- The encrypted string.
     """
     import bcrypt
+
     return bytes(
         bcrypt.hashpw(bytes(password_string, "utf-8"), bcrypt.gensalt())
     ).decode("utf-8")

--- a/tests/features/event/test_event.py
+++ b/tests/features/event/test_event.py
@@ -59,9 +59,9 @@ class TestEvent(TestCase):
         self.event.listen(UserAddedEvent, [SendEmailListener])
 
     def test_events_registered(self):
-        self.assertEqual(len(self.event.get_events().get(UserAddedEvent)), 1)
-        self.event.listen(UserAddedEvent, [AdminNotificationListener])
         self.assertEqual(len(self.event.get_events().get(UserAddedEvent)), 2)
+        self.event.listen(UserAddedEvent, [AdminNotificationListener])
+        self.assertEqual(len(self.event.get_events().get(UserAddedEvent)), 3)
 
     def test_fire_event_class(self):
         self.event.fire(UserAddedEvent)

--- a/tests/features/event/test_event.py
+++ b/tests/features/event/test_event.py
@@ -8,8 +8,14 @@ from tests import TestCase
 
 
 class UserAddedEvent(Event):
-    subscribe = []
+    def __init__(self):
+        pass
 
+    def handle(self):
+        pass
+
+
+class NewUserEvent(Event):
     def __init__(self):
         pass
 
@@ -18,13 +24,19 @@ class UserAddedEvent(Event):
 
 
 class SendEmailListener:
-    def handle(self, event):
+    def handle(self):
         pass
 
 
 class UpdateAdminListener:
+    def handle(self, user):
+        print("update", user)
+        pass
+
+
+class SendAlert:
     def handle(self, event):
-        print("update", event)
+        print("eee", event)
         pass
 
 
@@ -58,3 +70,7 @@ class TestEvent(TestCase):
         self.assertEqual(self.event.fire("masonite.command"), [])
         self.assertEqual(self.event.fire("view.rendered"), ["view.*"])
         self.assertEqual(self.event.fire("user.added", 1), ["user.added"])
+
+    def test_fire_event_class(self):
+        self.event.listen(NewUserEvent, [SendAlert])
+        self.event.fire(NewUserEvent(), [])

--- a/tests/features/event/test_event.py
+++ b/tests/features/event/test_event.py
@@ -3,7 +3,6 @@ import time
 import pytest
 
 from src.masonite.events import Event
-from src.masonite.events.exceptions import InvalidSubscriptionType
 from tests import TestCase
 
 

--- a/tests/features/event/test_event.py
+++ b/tests/features/event/test_event.py
@@ -1,0 +1,159 @@
+import time
+
+import pytest
+
+from src.masonite.events import Event
+from src.masonite.events.exceptions import InvalidSubscriptionType
+from tests import TestCase
+
+
+class UserAddedEvent(Event):
+    subscribe = []
+
+    def __init__(self):
+        pass
+
+    def handle(self):
+        pass
+
+
+class SomeAction:
+    pass
+
+
+class EventListener:
+    def handle(self):
+        pass
+
+
+class EventWithSubscriber(Event):
+
+    subscribe = ["user.registered"]
+
+    def __init__(self):
+        pass
+
+    def handle(self):
+        pass
+
+
+class TestEvent(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.event = self.application.make("event")
+
+    def test_fire_event_with_wildcard_ends_with(self):
+        events = self.event.listen("user.registered", [EventListener, EventListener])
+
+        # events = self.app.make('Event').listen('user.subscribed', [
+        #     EventListener
+        # ])
+
+        # event = self.app.make('Event')
+
+        # assert event.fire('*.registered') is None
+        # assert isinstance(
+        #     event._fired_events['user.registered'][0], EventListener)
+
+    # def test_add_listener(self):
+    #     self.app.make('Event').listeners = {}
+    #     events = self.app.make('Event').listen(UserAddedEvent, [
+    #         EventListener
+    #     ])
+
+    #     assert events.listeners == {UserAddedEvent: [EventListener]}
+
+    #     events.listen(UserAddedEvent, [EventListener])
+
+    #     assert events.listeners == {
+    #         UserAddedEvent: [EventListener, EventListener]}
+
+    # def test_fire_event(self):
+    #     events = self.app.make('Event').listen(UserAddedEvent, [
+    #         EventListener
+    #     ])
+
+    #     assert events.fire(UserAddedEvent) is None
+    #     assert isinstance(
+    #         events._fired_events[UserAddedEvent][0], EventListener)
+
+    # def test_fire_event_with_wildcard_starts_with(self):
+    #     self.app.make('Event').listeners = {}
+    #     events = self.app.make('Event').listen('user.registered', [
+    #         EventListener
+    #     ])
+    #     events = self.app.make('Event').listen('user.subscribed', [
+    #         EventListener
+    #     ])
+
+    #     event = self.app.make('Event')
+
+    #     assert event.fire('user.*') is None
+    #     assert isinstance(
+    #         event._fired_events['user.registered'][0], EventListener)
+    #     assert isinstance(
+    #         event._fired_events['user.subscribed'][0], EventListener)
+
+    # def test_fire_event_with_wildcard_in_middle_of_fired_event(self):
+    #     self.app.make('Event').listeners = {}
+    #     events = self.app.make('Event').listen('user.manager.registered', [
+    #         EventListener
+    #     ])
+    #     events = self.app.make('Event').listen('user.owner.subscribed', [
+    #         EventListener
+    #     ])
+
+    #     event = self.app.make('Event')
+
+    #     assert event.fire('user.*.registered') is None
+    #     assert isinstance(
+    #         event._fired_events['user.manager.registered'][0], EventListener)
+
+    # def test_event_subscribers(self):
+    #     self.app.make('Event').listeners = {}
+    #     events = self.app.make('Event').subscribe(EventWithSubscriber)
+
+    #     assert self.app.make('Event').listeners == {
+    #         'user.registered': [EventWithSubscriber]}
+
+    # def test_event_with_multiple_subscribers(self):
+    #     self.app.make('Event').listeners = {}
+    #     event = EventWithSubscriber
+
+    #     event.subscribe = ['user.registered', 'user.subscribed']
+
+    #     self.app.make('Event').subscribe(event)
+
+    #     assert self.app.make('Event').listeners == {'user.registered': [
+    #         EventWithSubscriber], 'user.subscribed': [EventWithSubscriber]}
+
+    # def test_event_with_throws_exception_with_invalid_subscribe_attribute_type(self):
+    #     self.app.make('Event').listeners = {}
+    #     event = EventWithSubscriber
+
+    #     event.subscribe = 'user.registered'
+
+    #     with pytest.raises(InvalidSubscriptionType):
+    #         self.app.make('Event').subscribe(event)
+
+    # def test_event_starts_event_observer(self):
+    #     self.app.make('Event').listeners = {}
+    #     self.app.make('Event').event('user.subscribed')
+    #     assert self.app.make('Event').listeners == {'user.subscribed': []}
+
+    # def test_event_sets_keyword_arguments(self):
+    #     self.app.make('Event').listeners = {}
+    #     event = EventWithSubscriber
+
+    #     event.subscribe = ['user.registered', SomeAction]
+
+    #     self.app.make('Event').subscribe(event)
+
+    #     self.app.make('Event').fire('user.registered', to='user@email.com')
+    #     assert self.app.make('Event')._fired_events['user.registered'][0].argument(
+    #         'to') == 'user@email.com'
+
+    #     self.app.make('Event').fire(SomeAction, to='test@email.com')
+
+    #     assert self.app.make('Event')._fired_events[SomeAction][0].argument(
+    #         'to') == 'test@email.com'

--- a/tests/features/event/test_event.py
+++ b/tests/features/event/test_event.py
@@ -44,6 +44,14 @@ class AdminNotificationListener:
         pass
 
 
+class Subscriber:
+    def handle(self, event):
+        pass
+
+    def subscribe(self, event):
+        event.listen("masonite.event_handled", [self.__class__])
+
+
 class TestEvent(TestCase):
     def setUp(self):
         super().setUp()
@@ -73,3 +81,7 @@ class TestEvent(TestCase):
     def test_fire_event_class(self):
         self.event.listen(NewUserEvent, [SendAlert])
         self.event.fire(NewUserEvent(), [])
+
+    def test_can_subscribe(self):
+        self.event.subscribe(Subscriber())
+        self.event.fire("masonite.event_handled", ["masonite.event_handled"])

--- a/tests/integrations/config/providers.py
+++ b/tests/integrations/config/providers.py
@@ -9,6 +9,7 @@ from src.masonite.providers import (
     SessionProvider,
     QueueProvider,
     CacheProvider,
+    EventProvider,
 )
 
 from src.masonite.scheduling.providers import ScheduleProvider
@@ -25,4 +26,5 @@ PROVIDERS = [
     CacheProvider,
     QueueProvider,
     ScheduleProvider,
+    EventProvider,
 ]

--- a/tests/integrations/controllers/WelcomeController.py
+++ b/tests/integrations/controllers/WelcomeController.py
@@ -50,7 +50,7 @@ class WelcomeController(Controller):
         return response.json(
             {
                 "key": "value",
-                "key2": [1,2],
+                "key2": [1, 2],
                 "other_key": {
                     "nested": 1,
                     "nested_again": {"a": 1, "b": 2},
@@ -65,28 +65,21 @@ class WelcomeController(Controller):
 
     def session_with_errors(self, request: Request):
         request.app.make("session").driver("cookie").flash("key", "value")
-        request.app.make("session").driver("cookie").flash("errors", {
-            "email": "Email required",
-            "password": "Password too short",
-            "name": ""
-        })
+        request.app.make("session").driver("cookie").flash(
+            "errors",
+            {"email": "Email required", "password": "Password too short", "name": ""},
+        )
         return "session"
 
     def session2(self, request: Request):
-        request.app.make("session").driver("cookie").flash("key", {
-            "nested": 1,
-            "nested_again": {
-                "key2": "value2"
-            }
-        })
+        request.app.make("session").driver("cookie").flash(
+            "key", {"nested": 1, "nested_again": {"key2": "value2"}}
+        )
         return "session2"
 
     def with_params(self):
         return ""
 
     def auth(self, request: Request):
-        request.app.make("auth").guard("web").attempt(
-
-            "idmann509@gmail.com", "secret"
-        )
+        request.app.make("auth").guard("web").attempt("idmann509@gmail.com", "secret")
         return "logged in"

--- a/tests/tests/test_testcase.py
+++ b/tests/tests/test_testcase.py
@@ -50,13 +50,13 @@ class TestTestingAssertions(TestCase):
             ),
             Route.get("/test-redirect-1", "WelcomeController@redirect_url"),
             Route.get("/test-redirect-2", "WelcomeController@redirect_route"),
-            Route.get(
-                "/test-redirect-3", "WelcomeController@redirect_route_params"
-            ),
+            Route.get("/test-redirect-3", "WelcomeController@redirect_route_params"),
             Route.get("/test/@id", "WelcomeController@with_params").name("test_params"),
             Route.get("/test-json", "WelcomeController@json").name("json"),
             Route.get("/test-session", "WelcomeController@session").name("session"),
-            Route.get("/test-session-errors", "WelcomeController@session_with_errors").name("session"),
+            Route.get(
+                "/test-session-errors", "WelcomeController@session_with_errors"
+            ).name("session"),
             Route.get("/test-session-2", "WelcomeController@session2").name("session2"),
             Route.get("/test-authenticates", "WelcomeController@auth").name("auth"),
         )
@@ -123,7 +123,9 @@ class TestTestingAssertions(TestCase):
 
     def test_assert_redirect_to_route(self):
         self.get("/test-redirect-2").assertRedirect(name="test")
-        self.get("/test-redirect-3").assertRedirect(name="test_params", params={"id": 1})
+        self.get("/test-redirect-3").assertRedirect(
+            name="test_params", params={"id": 1}
+        )
 
     def test_assert_session_has(self):
         self.get("/test-session").assertSessionHas("key")
@@ -218,7 +220,9 @@ class TestTestingAssertions(TestCase):
     def test_assert_json(self):
         self.get("/test-json").assertJson({"key": "value"})
         # works also in a nested path
-        self.get("/test-json").assertJson({"other_key": {"nested": 1, "nested_again": {"a": 1, "b": 2}}})
+        self.get("/test-json").assertJson(
+            {"other_key": {"nested": 1, "nested_again": {"a": 1, "b": 2}}}
+        )
 
     def test_json_assertions_fail_when_response_not_json(self):
         with self.assertRaises(ValueError):
@@ -237,11 +241,13 @@ class TestTestingAssertions(TestCase):
         self.get("/test-json").assertJsonCount(2, key="other_key")
 
     def test_assert_json_exact(self):
-        self.get("/test-json").assertJsonExact({
-            "key": "value",
-            "key2": [1,2],
-            "other_key": {
-                "nested": 1,
-                "nested_again": {"a": 1, "b": 2},
-            },
-        })
+        self.get("/test-json").assertJsonExact(
+            {
+                "key": "value",
+                "key2": [1, 2],
+                "other_key": {
+                    "nested": 1,
+                    "nested_again": {"a": 1, "b": 2},
+                },
+            }
+        )


### PR DESCRIPTION
Closes #26 

This PR adds Event support. Usage is pretty simple. there are:

* events
* listeners

Events get fired and you have listeners that listen to the event. 

Listening will look something like this:

```python
self.application.make('event').listen("event", [EventListener])
```

When this event is fired then all the listeners will be fired.

Here would be a real world example:

```python
self.application.make('event').listen("view.rendered", [LogViewRendered])
```

We can then fire this event inside the application:

```python
self.application.make('event').fire('view.rendered')
```

Here are different ways we can use this:

```python
# Listening
self.application.make('event').listen("masonite.booted", [LogListener])
self.application.make('event').listen("masonite.*", [LogListener])
self.application.make('event').listen("*.booted", [LogListener])
self.application.make('event').listen("masonite.*.booted", [LogListener]) 
# Catches something like masonite.events.booted

# Firing
self.application.make('event').fire('masonite.booted')
self.application.make('event').fire('masonite.booted', parameter1, parameter2)
self.application.make('event').fire(MasoniteBooted)

self.application.make('event').fire(MasoniteBooted())
```

### TODO:

- [x] Subscribers