### PR TITLE
added event listener for exceptions

### DIFF
--- a/src/masonite/events/Event.py
+++ b/src/masonite/events/Event.py
@@ -29,13 +29,10 @@ class Event:
 
     def fire(self, event, *args, **kwargs):
         if isinstance(event, str):
-            if event in self.events:
-                for listener in self.events.get(event):
-                    listener().handle(*args, **kwargs)
             collected_events = self.collect_events(event)
             for collected_event in collected_events:
                 for listener in self.events.get(collected_event, []):
-                    listener().handle(event)
+                    listener().handle(event, *args, **kwargs)
             return collected_events
         else:
             if inspect.isclass(event):
@@ -44,8 +41,7 @@ class Event:
             else:
                 lookup = event.__class__
             for listener in self.events.get(lookup, []):
-                print("h")
-                listener().handle(event)
+                listener().handle(event, *args, **kwargs)
 
             return [event]
 

--- a/src/masonite/events/Event.py
+++ b/src/masonite/events/Event.py
@@ -33,6 +33,9 @@ class Event:
                 for listener in self.events.get(event):
                     listener().handle(*args, **kwargs)
             collected_events = self.collect_events(event)
+            for collected_event in collected_events:
+                for listener in self.events.get(collected_event, []):
+                    listener().handle(event)
             return collected_events
         else:
             if inspect.isclass(event):
@@ -41,6 +44,7 @@ class Event:
             else:
                 lookup = event.__class__
             for listener in self.events.get(lookup, []):
+                print("h")
                 listener().handle(event)
 
             return [event]

--- a/src/masonite/exceptions/ExceptionHandler.py
+++ b/src/masonite/exceptions/ExceptionHandler.py
@@ -29,6 +29,9 @@ class ExceptionHandler:
     def handle(self, exception):
         response = self.application.make("response")
         request = self.application.make("request")
+        self.application.make("event").fire(
+            f"masonite.exception.{exception.__class__.__name__}", exception
+        )
         handler = Handler(exception)
         handler.integrate(StackOverflowIntegration())
         handler.integrate(SolutionsIntegration())

--- a/tests/features/event/test_event.py
+++ b/tests/features/event/test_event.py
@@ -23,12 +23,12 @@ class NewUserEvent(Event):
 
 
 class SendEmailListener:
-    def handle(self):
+    def handle(self, event):
         pass
 
 
 class UpdateAdminListener:
-    def handle(self, user):
+    def handle(self, event, user):
         print("update", user)
         pass
 
@@ -85,8 +85,10 @@ class TestEvent(TestCase):
 
     def test_fire_event_class(self):
         self.event.listen(NewUserEvent, [SendAlert])
-        self.event.fire(NewUserEvent(), [])
+        self.event.fire(NewUserEvent())
 
     def test_can_subscribe(self):
         self.event.subscribe(Subscriber())
-        self.event.fire("masonite.event_handled", ["masonite.event_handled"])
+        self.assertEqual(
+            self.event.fire("masonite.event_handled"), ["masonite.event_handled"]
+        )

--- a/tests/features/event/test_event.py
+++ b/tests/features/event/test_event.py
@@ -70,11 +70,16 @@ class TestEvent(TestCase):
         self.event.listen("masonite.*.booted", [SendEmailListener])
         self.event.listen("masonite.commands", [SendEmailListener])
         self.event.listen("view.*", [SendEmailListener])
+        self.event.listen("masonite.exception.*", [SendEmailListener])
         self.event.listen("user.added", [UpdateAdminListener])
         self.assertEqual(self.event.fire("masonite.commands"), ["masonite.commands"])
         self.assertEqual(self.event.fire("masonite.orm.booted"), ["masonite.*.booted"])
         self.assertEqual(self.event.fire("masonite.orm"), [])
         self.assertEqual(self.event.fire("masonite.command"), [])
+        self.assertEqual(
+            self.event.fire("masonite.exception.ZeroDivisionError"),
+            ["masonite.exception.*"],
+        )
         self.assertEqual(self.event.fire("view.rendered"), ["view.*"])
         self.assertEqual(self.event.fire("user.added", 1), ["user.added"])
 


### PR DESCRIPTION
Closes #37 

@girardinsamuel here you can see how powerful this event system can be. Previously we did something similiar but this event system allows us to listen to all exceptions of the framework now. We can really easily add something like sentry to the app and listen to either a specific error: `masonite.exceptions.ZeroDivisionError` or we can listen to all exceptions: `masonite.exceptions.*` and send them all the Sentry or something. The sentry part if not in this PR this just adds support for something like that.

Or even for Masonite Logging