### PR TITLE
Fix mailable default values

### DIFF
--- a/src/masonite/mail/Mailable.py
+++ b/src/masonite/mail/Mailable.py
@@ -4,8 +4,8 @@ from .MessageAttachment import MessageAttachment
 class Mailable:
     def __init__(self):
         self._to = ""
-        self._cc = None
-        self._bcc = None
+        self._cc = ""
+        self._bcc = ""
         self._from = ""
         self._reply_to = ""
         self._subject = ""

--- a/tests/features/mail/test_mock_mail.py
+++ b/tests/features/mail/test_mock_mail.py
@@ -18,8 +18,8 @@ class TestSMTPDriver(TestCase):
         self.fake("mail")
         welcome_email = self.application.make("mail").mailable(Welcome()).send()
         (
-            welcome_email.seeEmailCc(None)
-            .seeEmailBcc(None)
+            welcome_email.seeEmailCc("")
+            .seeEmailBcc("")
             .seeEmailContains("Hello from Masonite!")
             .seeEmailContains("text from Masonite!")
             .seeEmailFrom("joe@masoniteproject.com")


### PR DESCRIPTION
It's a small fix (which could have been done also in terminal driver), to fix 
sending email with terminal driver without any CC or BCC defined in the Mailable.

There was an issue converting CC and BCC equals to `None` as Recipient (when the email is printed in terminal), this line is causing the error:
```python
print(f"Cc: {Recipient(self.options.get('cc')).header()}")
```
