### PR TITLE
Add seed for creating one test user

### DIFF
--- a/tests/integrations/databases/migrations/2021_01_09_043202_create_users_table.py
+++ b/tests/integrations/databases/migrations/2021_01_09_043202_create_users_table.py
@@ -11,6 +11,7 @@ class CreateUsersTable(Migration):
             table.string("password")
             table.string("second_password").nullable()
             table.string("remember_token").nullable()
+            table.string("phone").nullable()
             table.timestamp("verified_at").nullable()
             table.timestamps()
 

--- a/tests/integrations/databases/seeds/database_seeder.py
+++ b/tests/integrations/databases/seeds/database_seeder.py
@@ -1,0 +1,10 @@
+"""Base Database Seeder Module."""
+
+from masoniteorm.seeds import Seeder
+from .user_table_seeder import UserTableSeeder
+
+
+class DatabaseSeeder(Seeder):
+    def run(self):
+        """Run the database seeds."""
+        self.call(UserTableSeeder)

--- a/tests/integrations/databases/seeds/user_table_seeder.py
+++ b/tests/integrations/databases/seeds/user_table_seeder.py
@@ -1,0 +1,17 @@
+"""UserTableSeeder Seeder."""
+
+from masoniteorm.seeds import Seeder
+from tests.integrations.app.User import User
+
+
+class UserTableSeeder(Seeder):
+    def run(self):
+        """Run the database seeds."""
+        User.create(
+            {
+                "name": "idmann509",
+                "email": "idmann509@gmail.com",
+                "password": "secret",
+                "phone": "+123456789",
+            }
+        )


### PR DESCRIPTION
As I deleted the db locally, I wanted to recreate it, so I added a seeder to create the one User used during testing. (On which I added a phone number).

But for now I can't run this seed because ORM seed command does not take a directory flag. (so what I did locally was to move the seed folder at root "databases/seeds/" and then I could ran the seeds.)

It's a small PR but handy for development and maybe to add in a CONTRIBUTING to explain how to setup M4 locally for contributing.