### PR TITLE
Proposition: add ability to install dev dependencies easily

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 init:
 	pip install -r requirements.txt
-	pip install .
+	pip install '.[test]'
 	# Create MySQL Database
 	# Create Postgres Database
 test:

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,6 @@ setup(
         "masonite.tests",
         "masonite.utils",
         "masonite.views",
-
     ],
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
@@ -100,7 +99,14 @@ setup(
     # $ pip install -e .[dev,test]
     # $ pip install your-package[dev,test]
     extras_require={
-        "test": ["coverage", "pytest"],
+        "test": [
+            "coverage",
+            "pytest",
+            "redis",
+            "boto3",
+            "pusher",
+            "pymemcache",
+        ],
     },
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these


### PR DESCRIPTION
For now when running tests suite in a local env, some dependencies are missing. We don't want to add them
as framework dependencies as some users won't need those. Instead we just want to install those for
testing purposes.

1. I choosed to add them in "test" dependencies extra.
2. Also `make init` which is a developer command should maybe install those ? That is why I edited the makefile to install the extra dependencies.

