### PR TITLE
WIP: Fix tinker command and add IPython option

### DIFF
--- a/src/masonite/commands/TinkerCommand.py
+++ b/src/masonite/commands/TinkerCommand.py
@@ -4,9 +4,13 @@ import sys
 
 from cleo import Command
 
+from ..utils.collections import Collection
+from ..utils.structures import load
+
 BANNER = """Masonite Python {} Console
 This interactive console has the following things imported:
     container as 'app'
+    Collection, load
 
 Type `exit()` to exit."""
 
@@ -26,9 +30,9 @@ class TinkerCommand(Command):
             sys.version_info.major, sys.version_info.minor, sys.version_info.micro
         )
         banner = BANNER.format(version)
+        context = {"app": application, "Collection": Collection, "load": load}
 
         if self.option("ipython"):
-
             try:
                 import IPython
             except ImportError:
@@ -38,11 +42,7 @@ class TinkerCommand(Command):
             from traitlets.config import Config
 
             c = Config()
-            # c.InteractiveShellApp.exec_lines = [
-            #     'print("\\nimporting some things\\n")',
-            # ]
             c.TerminalInteractiveShell.banner1 = banner
-            context = {"app": application}
             IPython.start_ipython(argv=[], user_ns=context, config=c)
         else:
-            code.interact(banner=banner, local={"app": application})
+            code.interact(banner=banner, local=context)

--- a/src/masonite/commands/TinkerCommand.py
+++ b/src/masonite/commands/TinkerCommand.py
@@ -19,11 +19,11 @@ class TinkerCommand(Command):
     """
 
     def handle(self):
-        from wsgi import container
+        from wsgi import application
 
         version = "{}.{}.{}".format(
             sys.version_info.major, sys.version_info.minor, sys.version_info.micro
         )
         banner = BANNER.format(version)
 
-        code.interact(banner=banner, local={"app": container})
+        code.interact(banner=banner, local={"app": application})

--- a/src/masonite/commands/TinkerCommand.py
+++ b/src/masonite/commands/TinkerCommand.py
@@ -16,6 +16,7 @@ class TinkerCommand(Command):
     Run a python shell with the container pre-loaded.
 
     tinker
+        {--i|ipython : Run a IPython shell}
     """
 
     def handle(self):
@@ -26,4 +27,22 @@ class TinkerCommand(Command):
         )
         banner = BANNER.format(version)
 
-        code.interact(banner=banner, local={"app": application})
+        if self.option("ipython"):
+
+            try:
+                import IPython
+            except ImportError:
+                raise ModuleNotFoundError(
+                    "Could not find the 'IPython' library. Run 'pip install ipython' to fix this."
+                )
+            from traitlets.config import Config
+
+            c = Config()
+            # c.InteractiveShellApp.exec_lines = [
+            #     'print("\\nimporting some things\\n")',
+            # ]
+            c.TerminalInteractiveShell.banner1 = banner
+            context = {"app": application}
+            IPython.start_ipython(argv=[], user_ns=context, config=c)
+        else:
+            code.interact(banner=banner, local={"app": application})

--- a/src/masonite/commands/TinkerCommand.py
+++ b/src/masonite/commands/TinkerCommand.py
@@ -1,7 +1,10 @@
 """Starts Interactive Console Command."""
 import code
 import sys
-
+import pkgutil
+import importlib
+import inspect
+import os
 from cleo import Command
 
 from ..utils.collections import Collection
@@ -9,8 +12,9 @@ from ..utils.structures import load
 
 BANNER = """Masonite Python {} Console
 This interactive console has the following things imported:
-    container as 'app'
-    Collection, load
+    container as 'app',
+    {},
+    {}
 
 Type `exit()` to exit."""
 
@@ -23,14 +27,39 @@ class TinkerCommand(Command):
         {--i|ipython : Run a IPython shell}
     """
 
+    def autoload_models(self, directories=[]):
+        from masoniteorm.models import Model
+
+        instance = Model
+        classes = {}
+        for (module_loader, name, _) in pkgutil.iter_modules(directories):
+            search_path = module_loader.path
+            for obj in inspect.getmembers(
+                self._get_module_members(module_loader, name)
+            ):
+                if inspect.isclass(obj[1]) and issubclass(obj[1], instance):
+                    if obj[1].__module__.startswith(search_path.replace("/", ".")):
+                        classes.update({obj[1].__name__: obj[1]})
+        return classes
+
+    def _get_module_members(self, module_loader, name):
+        search_path = module_loader.path
+        if search_path.endswith("/"):
+            raise Exception("Autoload path cannot have a trailing slash")
+
+        return importlib.import_module(
+            module_loader.path.replace("/", ".") + "." + name
+        )
+
     def handle(self):
         from wsgi import application
 
         version = "{}.{}.{}".format(
             sys.version_info.major, sys.version_info.minor, sys.version_info.micro
         )
-        banner = BANNER.format(version)
-        context = {"app": application, "Collection": Collection, "load": load}
+        models = self.autoload_models(["tests/integrations/app"])
+        banner = BANNER.format(version, "Collection, load", ",".join(models.keys()))
+        context = {"app": application, "Collection": Collection, "load": load, **models}
 
         if self.option("ipython"):
             try:


### PR DESCRIPTION
Fixes #72.

We can now run `python craft tinker --i` to have a fully featured IPython shells.
I started adding some utilities beside app in the shell.

One last thing I would like to do is to load all models. Most often I am using the shell to make some queries and it would be great to be able to have all models already imported to be able to directly do `User.all()`. But models are not defined in a specific location so it might be difficult...

Should we parse project directory for classes subclassing ORM `Model` classes ? For now I tried with hardcoded "tests/integrations/app" directory and autoloader from M3.

Here is the result:
![image](https://user-images.githubusercontent.com/9897999/111988563-f456d100-8b10-11eb-9037-22bdf0ed2749.png)
