### PR TITLE
Improve app secret key resolving

### DIFF
--- a/src/masonite/auth/Sign.py
+++ b/src/masonite/auth/Sign.py
@@ -22,9 +22,9 @@ class Sign:
         if key:
             self.key = key
         else:
-            from config import application
+            from wsgi import application
 
-            self.key = application.KEY
+            self.key = application.make("key")
 
         if not self.key:
             raise InvalidSecretKey(

--- a/src/masonite/foundation/Kernel.py
+++ b/src/masonite/foundation/Kernel.py
@@ -39,6 +39,9 @@ class Kernel:
         LoadEnvironment()
 
     def set_framework_options(self):
+        self.application.bind(
+            "config.application", "tests.integrations.config.application"
+        )
         self.application.bind("config.mail", "tests.integrations.config.mail")
         self.application.bind("config.session", "tests.integrations.config.session")
         self.application.bind("config.queue", "tests.integrations.config.queue")
@@ -93,11 +96,12 @@ class Kernel:
         self.application.use_storage_path(
             os.path.join(self.application.base_path, "storage")
         )
-
         self.application.bind("routes.web", "tests.integrations.web.Route")
-        self.application.bind(
-            "sign", Sign("-RkDOqXojJIlsF_I8wWiUq_KRZ0PtGWTOZ676u5HtLg=")
-        )
+
+        key = load(self.application.make("config.application")).KEY
+        self.application.bind("key", key)
+        self.application.bind("sign", Sign(key))
+
         self.application.bind("base_url", "http://localhost:8000")
         self.application.bind("resolver", DB)
         self.application.bind("jobs.location", "tests/integrations/jobs")

--- a/tests/integrations/config/application.py
+++ b/tests/integrations/config/application.py
@@ -1,0 +1,3 @@
+import os
+
+KEY = os.getenv("APP_KEY", "-RkDOqXojJIlsF_I8wWiUq_KRZ0PtGWTOZ676u5HtLg=")


### PR DESCRIPTION
`python craft key` can generate a key stored in .env in `APP_KEY` env variable.

- This variable can now be used in a new `config/application.py` file, this file location can be changed as for others.
- The key is now bound inside the container and we can get the key by doing `application.make("key")`
