### PR TITLE
Add datetime testing utils to mock datetimes during tests

### DIFF
--- a/tests/TestCase.py
+++ b/tests/TestCase.py
@@ -1,5 +1,6 @@
 import json
 import io
+import pendulum
 
 from src.masonite.tests import TestCase
 from src.masonite.routes import Route, RouteCapsule
@@ -144,3 +145,37 @@ class TestCase(TestCase):
         """Restore the service previously mocked to the original one."""
         original = self.original_class_mocks.get(binding)
         self.application.bind(binding, original)
+
+    def fakeTime(self, pendulum_datetime):
+        """Set a given pendulum instance to be returned when a "now" (or "today", "tomorrow",
+        "yesterday") instance is created. It's really useful during tests to check
+        timestamps logic."""
+        pendulum.set_test_now(pendulum_datetime)
+
+    def fakeTimeTomorrow(self):
+        """Set the mocked time as tomorrow."""
+        self.fakeTime(pendulum.tomorrow())
+
+    def fakeTimeYesterday(self):
+        """Set the mocked time as yesterday."""
+        self.fakeTime(pendulum.yesterday())
+
+    def fakeTimeInFuture(self, offset, unit="days"):
+        """Set the mocked time as an offset of days in the future. Unit can be specified
+        among pendulum units: seconds, minutes, hours, days, weeks, months, years."""
+        self.restoreTime()
+        datetime = pendulum.now().add(**{unit: offset})
+        self.fakeTime(datetime)
+
+    def fakeTimeInPast(self, offset, unit="days"):
+        """Set the mocked time as an offset of days in the past. Unit can be specified
+        among pendulum units: seconds, minutes, hours, days, weeks, months, years."""
+        self.restoreTime()
+        datetime = pendulum.now().subtract(**{unit: offset})
+        self.fakeTime(datetime)
+
+    def restoreTime(self):
+        """Restore time to correct one, so that pendulum new "now" instance are corrects.
+        This method will be typically called in tearDown() method of a test class."""
+        # this will clear the mock
+        pendulum.set_test_now()

--- a/tests/tests/test_testcase.py
+++ b/tests/tests/test_testcase.py
@@ -1,3 +1,5 @@
+import pendulum
+
 from tests import TestCase
 from tests.integrations.controllers.WelcomeController import WelcomeController
 from masoniteorm.models import Model
@@ -16,12 +18,51 @@ class TestTestCase(TestCase):
             Route.get("/", "WelcomeController@show").name("home"),
         )
 
+    def tearDown(self):
+        super().tearDown()
+        self.restoreTime()
+
     def test_add_routes(self):
         self.assertEqual(len(self.application.make("router").routes), 1)
         self.addRoutes(
             Route.get("/test", "WelcomeController@show").name("test"),
         )
         self.assertEqual(len(self.application.make("router").routes), 2)
+
+    def test_fake_time(self):
+        given_date = pendulum.datetime(2015, 2, 5)
+        self.fakeTime(given_date)
+        self.assertEqual(pendulum.now(), given_date)
+        self.restoreTime()
+        self.assertNotEqual(pendulum.now(), given_date)
+
+    def test_fake_time_tomorrow(self):
+        tomorrow = pendulum.tomorrow()
+        self.fakeTimeTomorrow()
+        self.assertEqual(pendulum.now(), tomorrow)
+
+    def test_fake_time_yesterday(self):
+        yesterday = pendulum.yesterday()
+        self.fakeTimeYesterday()
+        self.assertEqual(pendulum.now(), yesterday)
+
+    def test_fake_time_in_future(self):
+        real_now = pendulum.now()
+        self.fakeTimeInFuture(10)
+        self.assertEqual(pendulum.now().diff(real_now).in_days(), 10)
+        self.assertGreater(pendulum.now(), real_now)
+
+        self.fakeTimeInFuture(1, "months")
+        self.assertEqual(pendulum.now().diff(real_now).in_months(), 1)
+
+    def test_fake_time_in_past(self):
+        real_now = pendulum.now()
+        self.fakeTimeInPast(10)
+        self.assertEqual(pendulum.now().diff(real_now).in_days(), 10)
+        self.assertLess(pendulum.now(), real_now)
+
+        self.fakeTimeInPast(3, "hours")
+        self.assertEqual(real_now.hour - pendulum.now().hour, 3)
 
 
 class TestTestingAssertions(TestCase):


### PR DESCRIPTION
Add ability to travel in past or future during tests to easily check timestamps logic.

This PR adds the following methods to TestCase:
```python
fakeTimeTomorrow()
fakeTimeYesterday()
given_date = pendulum.datetime(2015, 2, 5)
fakeTime(given_date)
fakeTimeInPast(10, "hours")
fakeTimeInFuture(1, "months")
```
Above can be reset with `restoreTime()` method which can be typically put at the end of tests or in test `tearDown` method.

More details in the unit tests !
