### PR TITLE
Add database testing assertions

### DIFF
--- a/tests/TestCase.py
+++ b/tests/TestCase.py
@@ -144,3 +144,34 @@ class TestCase(TestCase):
         """Restore the service previously mocked to the original one."""
         original = self.original_class_mocks.get(binding)
         self.application.bind(binding, original)
+
+    def assertDatabaseCount(self, table, count):
+        self.assertEqual(self.application.make("builder").table(table).count(), count)
+
+    def assertDatabaseHas(self, table, query_dict):
+        self.assertGreaterEqual(
+            self.application.make("builder").table(table).where(query_dict).count(), 1
+        )
+
+    def assertDatabaseMissing(self, table, query_dict):
+        self.assertEqual(
+            self.application.make("builder").table(table).where(query_dict).count(), 0
+        )
+
+    def assertDeleted(self, instance):
+        self.assertFalse(
+            self.application.make("builder")
+            .table(instance.get_table_name())
+            .where(instance.get_primary_key(), instance.get_primary_key_value())
+            .get()
+        )
+
+    def assertSoftDeleted(self, instance):
+        deleted_at_column = instance.get_deleted_at_column()
+        self.assertTrue(
+            self.application.make("builder")
+            .table(instance.get_table_name())
+            .where(instance.get_primary_key(), instance.get_primary_key_value())
+            .where_not_null(deleted_at_column)
+            .get()
+        )

--- a/tests/tests/test_testcase.py
+++ b/tests/tests/test_testcase.py
@@ -245,3 +245,14 @@ class TestTestingAssertions(TestCase):
                 },
             }
         )
+
+    def test_assert_database_count(self):
+        self.assertDatabaseCount("users", 1)
+
+    def test_assert_database_has(self):
+        self.assertDatabaseHas("users", {"name": "Joe"})
+
+    def test_assert_database_missing(self):
+        self.assertDatabaseMissing(
+            "users", {"name": "John", "email": "john@example.com"}
+        )

--- a/tests/tests/test_transactions.py
+++ b/tests/tests/test_transactions.py
@@ -12,3 +12,8 @@ class TestDatabase(TestCase, DatabaseTransactions):
 
     def test_can_use_transactions(self):
         User.create({"name": "john", "email": "john6", "password": "secret"})
+
+    def test_assert_deleted(self):
+        user = User.find(1)
+        user.delete()
+        self.assertDeleted(user)


### PR DESCRIPTION
This PR adds useful and simple database testing assertions:

```python
self.assertDatabaseCount("users", 3)
self.assertDatabaseHas("users", {"name": "Sam", "id": 2})
self.assertDatabaseMissing("users", {"name": "John"})

user = User.find(1)
user.delete()
self.assertDeleted(user)
self.assertSoftDeleted(user) # == same but for models with soft delete mixin
```
