### PR TITLE
Improve asserting response content

### DIFF
--- a/src/masonite/foundation/Application.py
+++ b/src/masonite/foundation/Application.py
@@ -10,7 +10,6 @@ class Application(Container):
         self.response_handler = None
         self.providers = []
 
-
     def set_response_handler(self, response_handler):
         self.response_handler = response_handler
 

--- a/src/masonite/tests/HttpTestResponse.py
+++ b/src/masonite/tests/HttpTestResponse.py
@@ -18,16 +18,24 @@ class HttpTestResponse:
         self.content = self.response.get_response_content()
         return self
 
+    def get_content(self):
+        """Take care of decoding content if bytes and returns str."""
+        return (
+            self.content.decode("utf-8")
+            if isinstance(self.content, bytes)
+            else str(self.content)
+        )
+
     def assertContains(self, content):
-        assert content in str(self.content), f"{content} not found."
+        assert content in self.get_content(), f"{content} not found."
         return self
 
     def assertNotContains(self, content):
-        assert content not in str(self.content)
+        assert content not in self.get_content()
         return self
 
     def assertContainsInOrder(self, *content):
-        response_content = str(self.content)
+        response_content = self.get_content()
         index = 0
         for content_string in content:
             found_at_index = response_content.find(content_string, index)
@@ -72,7 +80,7 @@ class HttpTestResponse:
         return self
 
     def assertNoContent(self, status=204):
-        assert not self.content.decode("utf-8")
+        assert not self.get_content()
         return self.assertIsStatus(status)
 
     def assertUnauthorized(self):
@@ -96,7 +104,7 @@ class HttpTestResponse:
     def assertRedirect(self, url=None, name=None, params={}):
         # we could assert 301 or 302 code => what if user uses another status code in redirect()
         # here we are sure
-        assert self.content.decode("utf-8") == "Redirecting ..."
+        assert self.get_content() == "Redirecting ..."
         if url:
             self.assertLocation(url)
         elif name:


### PR DESCRIPTION
Different assertions were asserting response content so I refactored cleaning content (decoding if bytes and ensuring it's a string) in one place.

Tiny PR that fixes an issue I had with asserting a bytes response which was not decoded