### PR TITLE
added static asset

### DIFF
--- a/src/masonite/providers/HelpersProvider.py
+++ b/src/masonite/providers/HelpersProvider.py
@@ -1,5 +1,6 @@
 import builtins
 from ..providers import Provider
+from ..utils.helpers import AssetHelper
 
 
 class HelpersProvider(Provider):
@@ -18,6 +19,7 @@ class HelpersProvider(Provider):
                 "auth": request.user,
                 "route": self.application.make("router").route,
                 "cookie": request.cookie,
+                "asset": AssetHelper(self.application).asset,
                 "url": lambda name, params={}: (
                     self.application.make("base_url")
                     + self.application.make("router").route(name, params)

--- a/src/masonite/providers/HelpersProvider.py
+++ b/src/masonite/providers/HelpersProvider.py
@@ -1,6 +1,6 @@
 import builtins
 from ..providers import Provider
-from ..utils.helpers import AssetHelper
+from ..utils.helpers import AssetHelper, UrlHelper
 
 
 class HelpersProvider(Provider):
@@ -20,6 +20,7 @@ class HelpersProvider(Provider):
                 "route": self.application.make("router").route,
                 "cookie": request.cookie,
                 "asset": AssetHelper(self.application).asset,
+                "url_path": UrlHelper(self.application).url,
                 "url": lambda name, params={}: (
                     self.application.make("base_url")
                     + self.application.make("router").route(name, params)

--- a/src/masonite/utils/helpers.py
+++ b/src/masonite/utils/helpers.py
@@ -45,13 +45,15 @@ class AssetHelper:
 
         return "{}/{}".format(location, file_name)
 
+
 class UrlHelper:
     def __init__(self, app):
         self.app = app
 
     def url(self, url):
-        base_url = self.app.make("base_url").rstrip("/")  # just ensure that no slash is appended to the url
-
+        base_url = self.app.make("base_url").rstrip(
+            "/"
+        )  # just ensure that no slash is appended to the url
 
         return f"{base_url}/{url}"
 

--- a/src/masonite/utils/helpers.py
+++ b/src/masonite/utils/helpers.py
@@ -1,3 +1,7 @@
+import os
+from .structures import load
+
+
 def flatten(routes):
     """Flatten the grouped lists of lists into a single list.
 
@@ -16,6 +20,30 @@ def flatten(routes):
             route_collection.append(route)
 
     return route_collection
+
+
+class AssetHelper:
+    def __init__(self, app):
+        self.app = app
+
+    def asset(self, alias, file_name):
+        disks = load(self.app.make("config.filesystem")).DISKS
+
+        if "." in alias:
+            alias = alias.split(".")
+            location = disks[alias[0]]["path"][alias[1]]
+            if location.endswith("/"):
+                location = location[:-1]
+
+            return "{}/{}".format(location, file_name)
+
+        location = disks[alias]["path"]
+        if isinstance(location, dict):
+            location = list(location.values())[0]
+            if location.endswith("/"):
+                location = location[:-1]
+
+        return "{}/{}".format(location, file_name)
 
 
 """Helper Functions for working with Status Codes."""

--- a/src/masonite/utils/helpers.py
+++ b/src/masonite/utils/helpers.py
@@ -45,6 +45,16 @@ class AssetHelper:
 
         return "{}/{}".format(location, file_name)
 
+class UrlHelper:
+    def __init__(self, app):
+        self.app = app
+
+    def url(self, url):
+        base_url = self.app.make("base_url").rstrip("/")  # just ensure that no slash is appended to the url
+
+
+        return f"{base_url}/{url}"
+
 
 """Helper Functions for working with Status Codes."""
 

--- a/tests/integrations/app/Kernel/Kernel.py
+++ b/tests/integrations/app/Kernel/Kernel.py
@@ -47,7 +47,7 @@ class Kernel:
 
         self.application.bind("routes.web", "tests.integrations.web")
 
-        self.application.make('router').add(
+        self.application.make("router").add(
             Route.group(
                 load_routes(self.application.make("routes.web")), middleware="web"
             )
@@ -96,7 +96,7 @@ class Kernel:
         storage = StorageCapsule(self.application.base_path)
         storage.add_storage_assets(
             {
-                # folder          # template alias
+                # folder                             # template alias
                 "tests/integrations/storage/static": "static/",
                 "tests/integrations/storage/compiled": "static/",
                 "tests/integrations/storage/uploads": "static/",

--- a/tests/integrations/storage/static/main.css
+++ b/tests/integrations/storage/static/main.css
@@ -1,0 +1,3 @@
+html {
+    background-color: #ccc;
+}

--- a/tests/integrations/templates/welcome.html
+++ b/tests/integrations/templates/welcome.html
@@ -8,9 +8,14 @@ Hello. Setup chat connection here
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
     <script src="https://js.pusher.com/7.0/pusher.min.js"></script>
+    <link rel="stylesheet" href="/static/main.css">
 </head>
 <body>
     <h1>Welcome</h1>
+
+    <div>
+        <img src="{{ asset('local', 'original/image-20150902-6700-t2axrz.jpg') }}"
+    </div>
 
     <script>
         const pusher = new Pusher("", {

--- a/tests/integrations/templates/welcome.html
+++ b/tests/integrations/templates/welcome.html
@@ -13,10 +13,6 @@ Hello. Setup chat connection here
 <body>
     <h1>Welcome</h1>
 
-    <div>
-        <img src="{{ asset('local', 'original/image-20150902-6700-t2axrz.jpg') }}"
-    </div>
-
     <script>
         const pusher = new Pusher("", {
             authEndpoint: '/broadcasting/authorize',


### PR DESCRIPTION
Closes #83 

Theres 2 similar things here we need to separate:

* Static files (CSS, Logos, JS files, etc)
* Assets (Basically just user Uploads)

@girardinsamuel This code is mainly pulled from Masonite 3.

## Assets

You can set the paths on the disk. These paths will be the base directories where you assets are located:

```python
DISKS = {
    "default": "s3",
    "s3": {
        "driver": "file",
        "path": "https://s2.west2.amazon.com/public"
        #
    },
}
```

You can then use a new `asset()` view helper to concatenate the paths:

```html
<img src="{{ asset('s3', 'relative/path')"> <!-- https://s2.west2.amazon.com/public/relative/path -->
```

You can also structure the path as a dictionary and use dot notation:

```python
DISKS = {
    "default": "s3",
    "s3": {
        "driver": "file",
        "path": {
             'avatars': "https://s2.west2.amazon.com/public"
        }
        #
    },
}
```

```html
<img src="{{ asset('s3.avatars', 'relative/path')"> <!-- https://s2.west2.amazon.com/public/relative/path -->
```

## Static Files

Static files are treated a bit differently. These are files like CSS and JS files that do not change or get added throughout the life of the application deployment.

The way to do this is already really built in. We just alias the directory we want to serve static files from.

Most directories by default are aliased with the `/static/` alias. So you can alias any number of directories to `/static`. This configuration:

```python
storage.add_storage_assets(
            {
                # folder                             # template alias
                "tests/integrations/storage/static": "static/",
                "tests/integrations/storage/compiled": "static/",
                "tests/integrations/storage/uploads": "static/",
                "tests/integrations/storage/public": "/",
            }
        )
```

Allows any files in any of those directories on the left to be aliased in a template to `/static`:

```html
<link rel="stylesheet" href="/static/main.css">
```

I don't think we need a helper for this as it's already sorta aliased.

@girardinsamuel what are your thoughts?