### PR TITLE
Improve view/json assertions

### DIFF
--- a/src/masonite/tests/HttpTestResponse.py
+++ b/src/masonite/tests/HttpTestResponse.py
@@ -310,3 +310,10 @@ class HttpTestResponse:
             response_count == count
         ), f"JSON response count is {response_count}. Asserted {count}."
         return self
+
+    def assertJsonMissing(self, path):
+        """Assert that JSON response is JSON and does not contain given path.
+        The path can be a dotted path"""
+        response_data = self._ensure_response_is_json()
+        assert not Dot().dot(path, response_data)
+        return self

--- a/src/masonite/tests/HttpTestResponse.py
+++ b/src/masonite/tests/HttpTestResponse.py
@@ -193,9 +193,10 @@ class HttpTestResponse:
     def assertViewHas(self, key, value=None):
         """Assert that view context contains a given data key (and eventually associated value)."""
         self._ensure_response_has_view()
-        assert key in self.response.original.dictionary
+        value_at_key = Dot().dot(key, self.response.original.dictionary)
+        assert value_at_key
         if value:
-            assert self.response.original.dictionary[key] == value
+            assert value_at_key == value
         return self
 
     def assertViewHasExact(self, keys):
@@ -215,7 +216,7 @@ class HttpTestResponse:
     def assertViewMissing(self, key):
         """Assert that given data key is not in the view context."""
         self._ensure_response_has_view()
-        assert key not in self.response.original.dictionary
+        assert not Dot().dot(key, self.response.original.dictionary)
         return self
 
     def assertAuthenticated(self):

--- a/tests/integrations/controllers/WelcomeController.py
+++ b/tests/integrations/controllers/WelcomeController.py
@@ -73,7 +73,10 @@ class WelcomeController(Controller):
         return ""
 
     def view_with_context(self, view: View):
-        return view.render("welcome", {"count": 1, "users": ["John", "Joe"]})
+        return view.render(
+            "welcome",
+            {"count": 1, "users": ["John", "Joe"], "other_key": {"nested": 1}},
+        )
 
     def json(self, response: Response):
         return response.json(

--- a/tests/tests/test_testcase.py
+++ b/tests/tests/test_testcase.py
@@ -306,6 +306,12 @@ class TestTestingAssertions(TestCase):
             }
         )
 
+    def test_assert_json_missing(self):
+        self.get("/test-json").assertJsonMissing("key3")
+        self.get("/test-json").assertJsonMissing("some_key.nested")
+        with self.assertRaises(AssertionError):
+            self.get("/test-json").assertJsonMissing("other_key.nested")
+
     def test_assert_database_count(self):
         self.assertDatabaseCount("users", 1)
 

--- a/tests/tests/test_testcase.py
+++ b/tests/tests/test_testcase.py
@@ -120,8 +120,8 @@ class TestTestingAssertions(TestCase):
         )
 
     def test_assert_contains(self):
-        self.get("/").assertContains("welcome")
-        self.get("/").assertNotContains("welcome1")
+        self.get("/").assertContains("hello")
+        self.get("/").assertNotContains("welcome")
 
     def test_assert_is_named(self):
         self.get("/test").assertIsNamed("test")
@@ -203,6 +203,8 @@ class TestTestingAssertions(TestCase):
         self.get("/view-context").assertViewHas("count")
         self.get("/view-context").assertViewHas("count", 1)
         self.get("/view-context").assertViewHas("users", ["John", "Joe"])
+        self.get("/view-context").assertViewHas("other_key.nested")
+        self.get("/view-context").assertViewHas("other_key.nested", 1)
 
         with self.assertRaises(AssertionError):
             self.get("/view-context").assertViewHas("not_in_view")
@@ -218,9 +220,9 @@ class TestTestingAssertions(TestCase):
             self.get("/test").assertViewIs("test")
 
     def test_assert_view_has_exact(self):
-        self.get("/view-context").assertViewHasExact(["users", "count"])
+        self.get("/view-context").assertViewHasExact(["users", "count", "other_key"])
         self.get("/view-context").assertViewHasExact(
-            {"count": 1, "users": ["John", "Joe"]}
+            {"count": 1, "users": ["John", "Joe"], "other_key": {"nested": 1}}
         )
 
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
- Add `assertJsonMissing`
- Improve context view assertions by allowing using dotted paths
- Fix an unrelated failing test

```python
self.get("/").assertViewHas("some.dotted.path")
```