### PR TITLE
Update Jinja2 and fix deprecation warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "inflection>=0.3<0.4",
         "exceptionite>=1.0<1.1",
         "pendulum>=2,<3",
-        "jinja2>=2.11<2.12",
+        "jinja2>=3.0.0<3.1",
         "cleo>=0.8.1,<0.9",
         "hupper>=1.10,<1.11",
         "waitress>=1.4,<1.5",

--- a/src/masonite/middleware/route/VerifyCsrfToken.py
+++ b/src/masonite/middleware/route/VerifyCsrfToken.py
@@ -1,5 +1,5 @@
 from .. import Middleware
-from jinja2 import Markup
+from markupsafe import Markup
 from ...exceptions import InvalidCSRFToken
 from hmac import compare_digest
 

--- a/src/masonite/providers/HelpersProvider.py
+++ b/src/masonite/providers/HelpersProvider.py
@@ -1,7 +1,7 @@
 import builtins
 from ..providers import Provider
 from ..utils.helpers import AssetHelper, UrlHelper
-from jinja2 import Markup
+from markupsafe import Markup
 
 
 class HelpersProvider(Provider):


### PR DESCRIPTION
- Jinja2 has been updated
- The warning given here has been followed and implemented
```
VerifyCsrfToken.py:18: DeprecationWarning: 'jinja2.Markup' is deprecated and will be removed in Jinja 3.1. Import 'markupsafe.Markup' instead.
    "csrf_field": Markup(
```