### PR TITLE
Update config to be able to merge config from 3rd party packages

### DIFF
--- a/src/masonite/configuration/Configuration.py
+++ b/src/masonite/configuration/Configuration.py
@@ -60,7 +60,7 @@ class Configuration:
         """At boot load configuration from all files and store them in here."""
         config_root = self.application.make("config.location")
         for module_loader, name, _ in pkgutil.iter_modules([config_root]):
-            module = load_module(f"{relpath(module_loader.path)}.{name}")
+            module = load(f"{relpath(module_loader.path)}.{name}")
             params = self._get_params_from_module(module)
             for param in params:
                 self._config[f"{name}.{param[0].lower()}"] = param[1]
@@ -85,7 +85,7 @@ class Configuration:
             )
         if isinstance(external_config, str):
             # config is a path and should be loaded
-            module = load_module(external_config)
+            module = load(external_config)
             params = self._get_params_from_module(module)
             base_config = {name.lower(): value for name, value in params}
         else:

--- a/src/masonite/configuration/Configuration.py
+++ b/src/masonite/configuration/Configuration.py
@@ -58,7 +58,7 @@ class Configuration:
                 f"Config directory {config_root} does not contain required configuration files."
             )
 
-    def merge_config_with(self, path, external_config):
+    def merge_with(self, path, external_config):
         """Merge external config at key with project config at same key. It's especially
         useful in Masonite packages in order to merge the configuration default package with
         the package configuration which can be published in project.

--- a/src/masonite/configuration/Configuration.py
+++ b/src/masonite/configuration/Configuration.py
@@ -7,20 +7,33 @@ from dotty_dict import dotty
 from ..exceptions import InvalidConfigurationLocation, InvalidConfigurationSetup
 
 
-# from PR not merged
+# from PR #147 not merged yet, in the meantime hard-coded here
+# from ..utils.structures import load
+# from ..utils.str import modularize
+
+
 def modularize(path):
     return path.replace("/", ".").rstrip(".py")
 
 
-# add to PR:
-def load_module(module_path):
-    """Module path file or dotted :
-    tests/integrations/app/test.py
-    tests/integrations/app/test
-    tests.integrations.app.test
+def load(path, object_name=None, default=None):
+    """Load the given object from a Python module located at path and returns a default
+    value if not found. If no object name is provided, loads the module.
+
+    Arguments:
+        path {str} -- A file path or a dotted path of a Python module
+        object {str} -- The object name to load in this module (None)
+        default {str} -- The default value to return if object not found in module (None)
+    Returns:
+        {object} -- The value (or default) read in the module or the module if no object name
     """
-    module = pydoc.locate(modularize(module_path))
-    return module
+    # modularize path if needed
+    dotted_path = modularize(path)
+    module = pydoc.locate(dotted_path)
+    if object_name is None:
+        return module
+    else:
+        return getattr(module, object_name, default)
 
 
 class Configuration:

--- a/src/masonite/configuration/Configuration.py
+++ b/src/masonite/configuration/Configuration.py
@@ -1,13 +1,44 @@
-import importlib
 import inspect
 import pkgutil
+import pydoc
 from os.path import relpath
 from dotty_dict import dotty
 
-from ..exceptions import InvalidConfigurationLocation
+from ..exceptions import InvalidConfigurationLocation, InvalidConfigurationSetup
+
+
+# from PR not merged
+def modularize(path):
+    return path.replace("/", ".").rstrip(".py")
+
+
+# add to PR:
+def load_module(module_path):
+    """Module path file or dotted :
+    tests/integrations/app/test.py
+    tests/integrations/app/test
+    tests.integrations.app.test
+    """
+    module = pydoc.locate(modularize(module_path))
+    return module
 
 
 class Configuration:
+    # Foundation configuration keys
+    reserved_keys = [
+        "application",
+        "auth",
+        "broadcast",
+        "cache",
+        "database",
+        "filesystem",
+        "mail",
+        "notification",
+        "providers",
+        "queue",
+        "session",
+    ]
+
     def __init__(self, application):
         self.application = application
         self._config = dotty()
@@ -15,20 +46,41 @@ class Configuration:
     def load(self):
         """At boot load configuration from all files and store them in here."""
         config_root = self.application.make("config.location")
+        for module_loader, name, _ in pkgutil.iter_modules([config_root]):
+            module = load_module(f"{relpath(module_loader.path)}.{name}")
+            params = self._get_params_from_module(module)
+            for param in params:
+                self._config[f"{name}.{param[0].lower()}"] = param[1]
 
-        for (module_loader, name, _) in pkgutil.iter_modules([config_root]):
-            module_path = relpath(module_loader.path)
-            obj_in_modules = importlib.import_module(
-                module_path.replace("/", ".") + "." + name
-            )
-            for obj in inspect.getmembers(obj_in_modules):
-                if obj[0].isupper():
-                    self._config[f"{name}.{obj[0].lower()}"] = obj[1]
         # check loaded configuration
-        if len(self._config.keys()) == 0 or "application" not in self._config:
+        if not self._config.get("application"):
             raise InvalidConfigurationLocation(
                 f"Config directory {config_root} does not contain required configuration files."
             )
+
+    def merge_config_with(self, path, external_config):
+        """Merge external config at key with project config at same key. It's especially
+        useful in Masonite packages in order to merge the configuration default package with
+        the package configuration which can be published in project.
+
+        This functions disallow merging configuration using foundation configuration keys
+        (such as 'application'.)
+        """
+        if path in self.reserved_keys:
+            raise InvalidConfigurationSetup(
+                f"{path} is a reserved configuration key name. Please use an other key."
+            )
+        if isinstance(external_config, str):
+            # config is a path and should be loaded
+            module = load_module(external_config)
+            params = self._get_params_from_module(module)
+            base_config = {name.lower(): value for name, value in params}
+        else:
+            base_config = {
+                name.lower(): value for name, value in external_config.items()
+            }
+        merged_config = {**base_config, **self.get(path, {})}
+        self.set(path, merged_config)
 
     def set(self, path, value):
         self._config[path] = value
@@ -38,3 +90,15 @@ class Configuration:
             return self._config[path]
         except KeyError:
             return default
+
+    def _get_params_from_module(self, module):
+        params = []
+        for obj in inspect.getmembers(module):
+            obj_name = obj[0]
+            if (
+                obj_name.isupper()
+                and not obj_name.startswith("__")
+                and not obj_name.endswith("__")
+            ):
+                params.append(obj)
+        return params

--- a/src/masonite/exceptions/__init__.py
+++ b/src/masonite/exceptions/__init__.py
@@ -24,4 +24,5 @@ from .exceptions import (
     MixFileNotFound,
     MixManifestNotFound,
     InvalidConfigurationLocation,
+    InvalidConfigurationSetup,
 )

--- a/src/masonite/exceptions/exceptions.py
+++ b/src/masonite/exceptions/exceptions.py
@@ -124,3 +124,7 @@ class MixFileNotFound(Exception):
 
 class InvalidConfigurationLocation(Exception):
     pass
+
+
+class InvalidConfigurationSetup(Exception):
+    pass

--- a/tests/core/configuration/test_config.py
+++ b/tests/core/configuration/test_config.py
@@ -1,6 +1,11 @@
 from tests import TestCase
 from src.masonite.facades import Config
 from src.masonite.configuration import config
+from src.masonite.exceptions import InvalidConfigurationSetup
+
+
+PACKAGE_PARAM = 1
+OTHER_PARAM = 3
 
 
 class TestConfiguration(TestCase):
@@ -37,3 +42,27 @@ class TestConfiguration(TestCase):
         self.assertEqual(Config.get("cache.stores.redis.port"), 1000)
         # reset to original value
         Config.set("cache.stores.redis.port", original_value)
+
+    def test_can_load_non_foundation_config_in_project(self):
+        self.assertEqual(config("package.package_param"), "package_value")
+
+    def test_cannot_override_foundation_config(self):
+        with self.assertRaises(InvalidConfigurationSetup):
+            Config.merge_config_with("auth", {"key": "val"})
+
+    def test_can_merge_external_config_with_project_config(self):
+        # reset test package config for idempotent tests
+        Config.set("package", {"package_param": "package_value"})
+
+        package_default_config = {"PACKAGE_PARAM": "default_value", "OTHER_PARAM": 2}
+        Config.merge_config_with("package", package_default_config)
+        self.assertEqual(config("package.package_param"), "package_value")
+        self.assertEqual(config("package.other_param"), 2)
+
+    def test_can_merge_external_config_using_path(self):
+        # reset test package config for idempotent tests
+        Config.set("package", {"package_param": "package_value"})
+
+        Config.merge_config_with("package", "tests/core/configuration/test_config.py")
+        self.assertEqual(config("package.package_param"), "package_value")
+        self.assertEqual(config("package.other_param"), 3)

--- a/tests/core/configuration/test_config.py
+++ b/tests/core/configuration/test_config.py
@@ -48,14 +48,14 @@ class TestConfiguration(TestCase):
 
     def test_cannot_override_foundation_config(self):
         with self.assertRaises(InvalidConfigurationSetup):
-            Config.merge_config_with("auth", {"key": "val"})
+            Config.merge_with("auth", {"key": "val"})
 
     def test_can_merge_external_config_with_project_config(self):
         # reset test package config for idempotent tests
         Config.set("package", {"package_param": "package_value"})
 
         package_default_config = {"PACKAGE_PARAM": "default_value", "OTHER_PARAM": 2}
-        Config.merge_config_with("package", package_default_config)
+        Config.merge_with("package", package_default_config)
         self.assertEqual(config("package.package_param"), "package_value")
         self.assertEqual(config("package.other_param"), 2)
 
@@ -63,6 +63,6 @@ class TestConfiguration(TestCase):
         # reset test package config for idempotent tests
         Config.set("package", {"package_param": "package_value"})
 
-        Config.merge_config_with("package", "tests/core/configuration/test_config.py")
+        Config.merge_with("package", "tests/core/configuration/test_config.py")
         self.assertEqual(config("package.package_param"), "package_value")
         self.assertEqual(config("package.other_param"), 3)

--- a/tests/integrations/config/package.py
+++ b/tests/integrations/config/package.py
@@ -1,0 +1,3 @@
+"""External package settings for tests."""
+
+PACKAGE_PARAM = "package_value"


### PR DESCRIPTION
SHOULD BE MERGED ONCE #147  is merged !

In a package service provider we can do:

```python
from masonite.facades import Config

class MyPackageServiceProvider(Provider):

    def register(self):
        
        Config.merge_with("mypackage", abspath("mypackage/config.py"))
        # or 
        Config.merge_with("mypackage", "masonite.mypackage.config")
```
The function takes a file path or a module dotted path (whatever) and is loading parameters inside the module. Then it's overriden with eventual config for `mypackage` found in the project dir.

An exception will be raised if we try to use this for config (`application`, `auth`, ...).

## Summary
If a Masonite package is installed in your project and the package service provider is using `Config.merge_with`:
1. without publishing config file to the project, the package configuration will be accessible at `config("mypackage.param")`.
2. if the config is published to the project, the package configuration will be accessible at `config("mypackage.param")` and project parameters will take precedence over package default parameters.


This will be useful for #79.