### PR TITLE
Boot providers during tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pytest
 black
 cryptography
-https://github.com/girardinsamuel/orm/archive/refs/heads/feat/501.zip
+https://github.com/MasoniteFramework/orm/archive/2.0.zip
 python-dotenv
 waitress
 responses

--- a/src/masonite/providers/SessionProvider.py
+++ b/src/masonite/providers/SessionProvider.py
@@ -13,10 +13,9 @@ class SessionProvider(Provider):
         session = Session(self.application).set_configuration(config("session.drivers"))
         session.add_driver("cookie", CookieDriver(self.application))
         self.application.bind("session", session)
-        self.application.make("view").share({"old": self.old})
 
     def boot(self):
-        pass
+        self.application.make("view").share({"old": self.old})
 
     def old(self, key):
         return self.application.make("session").get(key) or ""

--- a/src/masonite/providers/SessionProvider.py
+++ b/src/masonite/providers/SessionProvider.py
@@ -13,9 +13,10 @@ class SessionProvider(Provider):
         session = Session(self.application).set_configuration(config("session.drivers"))
         session.add_driver("cookie", CookieDriver(self.application))
         self.application.bind("session", session)
+        self.application.make("view").share({"old": self.old})
 
     def boot(self):
-        self.application.make("view").share({"old": self.old})
+        pass
 
     def old(self, key):
         return self.application.make("session").get(key) or ""

--- a/tests/core/views/test_view.py
+++ b/tests/core/views/test_view.py
@@ -6,9 +6,10 @@ from tests import TestCase
 class TestView(TestCase):
     def setUp(self):
         super().setUp()
-        # keep this to have a fresh view instance for each test
+        # keep this to have a "fresh view instance" for each test
         self.view = self.application.make("view")
         self.view.loaders = []
+        self.view.composers = {}
         self.view.add_location("tests/integrations/templates")
 
     def test_can_pass_dict(self):
@@ -90,6 +91,8 @@ class TestView(TestCase):
         self.assertEqual(self.view.render("test").rendered_template, "test")
 
     def test_view_share_updates_dictionary_not_overwrite(self):
+        # reset shared data from views
+        self.view._shared = {}
         self.view.share({"test1": "test1"})
         self.view.share({"test2": "test2"})
 

--- a/tests/core/views/test_view.py
+++ b/tests/core/views/test_view.py
@@ -1,18 +1,15 @@
-import os
-from src.masonite.foundation import Application
-from src.masonite.views import View
-
+from src.masonite.configuration import config
+from src.masonite.helpers import url
 from tests import TestCase
 
 
 class TestView(TestCase):
     def setUp(self):
+        super().setUp()
         # keep this to have a fresh view instance for each test
-        self.view = View(Application(os.getcwd()))
+        self.view = self.application.make("view")
+        self.view.loaders = []
         self.view.add_location("tests/integrations/templates")
-
-    # def test_can_render_view(self):
-    #     self.assertTrue("Welcome" in self.view.render("welcome").get_content())
 
     def test_can_pass_dict(self):
         self.assertIn("test", self.view.render("test", {"test": "test"}).get_content())
@@ -105,3 +102,12 @@ class TestView(TestCase):
     def test_can_use_namespaced_view(self):
         self.view.add_namespaced_location("auth", "tests/integrations/templates/auth")
         self.assertIn("Welcome", self.view.render("auth:home").get_content())
+
+    def test_can_access_shared_helpers(self):
+        content = self.view.render("test_helpers").get_content()
+        self.assertIn(
+            config("application.app_url"),
+            content,
+        )
+        self.assertIn(url.asset("local", "avatar.jpg"), content)
+        self.assertIn(url.url("welcome"), content)

--- a/tests/core/views/test_view.py
+++ b/tests/core/views/test_view.py
@@ -91,16 +91,15 @@ class TestView(TestCase):
         self.assertEqual(self.view.render("test").rendered_template, "test")
 
     def test_view_share_updates_dictionary_not_overwrite(self):
-        # reset shared data from views
-        self.view._shared = {}
         self.view.share({"test1": "test1"})
         self.view.share({"test2": "test2"})
 
-        self.assertEqual(self.view._shared, {"test1": "test1", "test2": "test2"})
+        self.assertEqual(self.view._shared["test1"], "test1")
+        self.assertEqual(self.view._shared["test2"], "test2")
         self.view.render("test", {"var1": "var1"})
-        self.assertEqual(
-            self.view.dictionary, {"test1": "test1", "test2": "test2", "var1": "var1"}
-        )
+        self.assertIn("test1", self.view.dictionary.keys())
+        self.assertIn("test2", self.view.dictionary.keys())
+        self.assertIn("var1", self.view.dictionary.keys())
 
     def test_can_use_namespaced_view(self):
         self.view.add_namespaced_location("auth", "tests/integrations/templates/auth")

--- a/tests/integrations/templates/test_helpers.html
+++ b/tests/integrations/templates/test_helpers.html
@@ -1,0 +1,3 @@
+{{ config("application.app_url") }}
+{{ asset("local", "avatar.jpg") }}
+{{ url("welcome") }}


### PR DESCRIPTION
Fixes #153.

Here I don't load the RouteProvider during tests as we don't have a CSRF token yet. Of course it will be loaded when doing a request such as `self.get()` or an other method.

I added a test on view which is testing that helpers are correctly shared in views. They are shared during boot of ViewProvider, so this a proof that it is working 😉 