### PR TITLE
Use PYTHONSTARTUP in tinker command

### DIFF
--- a/src/masonite/commands/TinkerCommand.py
+++ b/src/masonite/commands/TinkerCommand.py
@@ -1,4 +1,5 @@
 """Starts Interactive Console Command."""
+import os
 import code
 import sys
 import pendulum
@@ -74,4 +75,19 @@ class TinkerCommand(Command):
             c.TerminalInteractiveShell.banner1 = banner
             IPython.start_ipython(argv=[], user_ns=context, config=c)
         else:
-            code.interact(banner=banner, local=context)
+            console = code.InteractiveConsole(context)
+            try:
+                import readline
+            except ImportError:
+                pass
+            # When not using IPython, PYTHONSTARTUP is not used by default, so load any
+            # scripts defined in this var at startup
+            startup_file = os.environ.get("PYTHONSTARTUP")
+            if startup_file:
+                if os.path.isfile(startup_file):
+                    with open(startup_file, "r") as f:
+                        compiled_code = code.compile_command(
+                            f.read(), startup_file, "exec"
+                        )
+                        console.runcode(compiled_code)
+            console.interact(banner, exitmsg="Goodbye !")


### PR DESCRIPTION
Summary : 

## Using `python craft tinker`
When using the simple mode, PYTHONSTARTUP script is not loaded if defined. This PR is fixing this by loading script defined in PYTHONSTARTUP (if any).

## Using `python craft tinker -i`
Using `Ipython` is the recommended way. This shell comes with a lot of features (auto completion, color highlighting and much more, see doc). This shell is automatically using PYTHONSTARTUP var meaning it will load any script defined in this env variable when starting the shell. Also it will load all scripts located in `~/.ipython/profile_default/startup/`.
This PR does not do anything when using IPython as the behaviour is already great.

Fix #205 (partially at least) => We really advise here to use Ipython mode because it comes with a lot of features (such as auto-reloading). It's less work and maintenance for much more features than trying to implement (not as good as what's inside ipython) some of those features.
In addition I don't really like using the bare `eval` or `exec` methods in Masonite code... (`IPython` is using a `safe_exec` method they have implemented).

About the changes I just added the content of `code.interact()` method instead of calling it directly as before: this allow us to access `console` instance that we can use to run additional code.