### PR TITLE
Fix using `setRoutes()` or `addRoutes()`

### DIFF
--- a/src/masonite/packages/providers/PackageProvider.py
+++ b/src/masonite/packages/providers/PackageProvider.py
@@ -129,12 +129,16 @@ class PackageProvider(Provider):
     def routes(self, *routes):
         """Controller locations must have been loaded already !"""
         self.package.add_routes(*routes)
+        print(len(self.application.make("router").routes))
         for route_group in self.package.routes:
             self.application.make("router").add(
                 Route.group(
                     load(route_group, "ROUTES", []),
                 )
             )
+        print(len(self.application.make("router").routes))
+        for route in self.application.make("router").routes:
+            print(route)
         return self
 
     def controllers(self, *controller_locations):

--- a/src/masonite/packages/providers/PackageProvider.py
+++ b/src/masonite/packages/providers/PackageProvider.py
@@ -129,16 +129,12 @@ class PackageProvider(Provider):
     def routes(self, *routes):
         """Controller locations must have been loaded already !"""
         self.package.add_routes(*routes)
-        print(len(self.application.make("router").routes))
         for route_group in self.package.routes:
             self.application.make("router").add(
                 Route.group(
                     load(route_group, "ROUTES", []),
                 )
             )
-        print(len(self.application.make("router").routes))
-        for route in self.application.make("router").routes:
-            print(route)
         return self
 
     def controllers(self, *controller_locations):

--- a/src/masonite/routes/HTTPRoute.py
+++ b/src/masonite/routes/HTTPRoute.py
@@ -38,6 +38,9 @@ class HTTPRoute:
         self.controller_bindings = controller_bindings
         self.compile_route_to_regex()
 
+    def __str__(self):
+        return f"<HttpRoute [{self._name}]: {self.url}>"
+
     def match(self, path, request_method, subdomain=None):
 
         route_math = (

--- a/src/masonite/tests/TestCase.py
+++ b/src/masonite/tests/TestCase.py
@@ -70,9 +70,7 @@ class TestCase(unittest.TestCase):
 
     def addRoutes(self, *routes):
         """Add routes to router during lifetime of a test."""
-        print("before", len(self.application.make("router").routes))
         self.application.make("router").add(Route.group(*routes, middleware=["web"]))
-        print("after", len(self.application.make("router").routes))
         return self
 
     def withCsrf(self):

--- a/src/masonite/tests/TestCase.py
+++ b/src/masonite/tests/TestCase.py
@@ -100,7 +100,7 @@ class TestCase(unittest.TestCase):
         self.application.bind("response", request)
         return request
 
-    def fetch(self, route, data=None, method=None):
+    def fetch(self, path, data=None, method=None):
         if data is None:
             data = {}
         if not self._csrf:
@@ -111,7 +111,7 @@ class TestCase(unittest.TestCase):
                     "HTTP_COOKIE": f"SESSID={token}; csrf_token={token}",
                     "CONTENT_LENGTH": len(str(json.dumps(data))),
                     "REQUEST_METHOD": method,
-                    "PATH_INFO": route,
+                    "PATH_INFO": path,
                     "wsgi.input": io.BytesIO(bytes(json.dumps(data), "utf-8")),
                 }
             )
@@ -120,7 +120,7 @@ class TestCase(unittest.TestCase):
                 {
                     "CONTENT_LENGTH": len(str(json.dumps(data))),
                     "REQUEST_METHOD": method,
-                    "PATH_INFO": route,
+                    "PATH_INFO": path,
                     "wsgi.input": io.BytesIO(bytes(json.dumps(data), "utf-8")),
                 }
             )
@@ -138,12 +138,12 @@ class TestCase(unittest.TestCase):
         for name, value in self._test_headers.items():
             request.header(name, value)
 
-        route = self.application.make("router").find(route, method)
+        route = self.application.make("router").find(path, method)
         if route:
             return self.application.make("tests.response").build(
                 self.application, request, response, route
             )
-        raise Exception(f"No route found for {route}")
+        raise Exception(f"No route found for url {path}")
 
     def mock_start_response(self, *args, **kwargs):
         pass

--- a/tests/TestCase.py
+++ b/tests/TestCase.py
@@ -3,9 +3,4 @@ from src.masonite.routes import Route
 
 
 class TestCase(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.addRoutes(
-            Route.get("/", "WelcomeController@show"),
-            Route.post("/", "WelcomeController@show"),
-        )
+    pass

--- a/tests/core/request/test_request_input.py
+++ b/tests/core/request/test_request_input.py
@@ -6,6 +6,7 @@ from src.masonite.request import Request
 
 class TestRequest(TestCase):
     def setUp(self):
+        super().setUp()
         self.request = Request(generate_wsgi(path="/test"))
 
     def test_request_no_input_returns_false(self):

--- a/tests/core/response/test_response_helpers.py
+++ b/tests/core/response/test_response_helpers.py
@@ -5,7 +5,7 @@ from src.masonite.routes import Route
 class TestResponseHelpers(TestCase):
     def setUp(self):
         super().setUp()
-        self.setRoutes(
+        self.addRoutes(
             Route.get("/test-with-errors", "WelcomeController@with_errors"),
             Route.get("/test-with-input", "WelcomeController@form_with_input"),
         )

--- a/tests/core/response/test_response_redirections.py
+++ b/tests/core/response/test_response_redirections.py
@@ -7,9 +7,9 @@ from src.masonite.routes import Router, Route
 
 class TestResponseRedirect(TestCase):
     def setUp(self):
-        application = Application(os.getcwd())
-        application.bind("router", Router(Route.get("/", None).name("home")))
-        self.response = Response(application)
+        super().setUp()
+        self.addRoutes(Route.get("/", None).name("home-redirect"))
+        self.response = Response(self.application)
 
     def test_redirect(self):
         self.response.redirect("/")
@@ -17,7 +17,7 @@ class TestResponseRedirect(TestCase):
         self.assertEqual(self.response.header_bag.get("Location").value, "/")
 
     def test_redirect_to_route_named_route(self):
-        self.response.redirect(name="home")
+        self.response.redirect(name="home-redirect")
         self.assertEqual(self.response.get_status(), 302)
         self.assertEqual(self.response.header_bag.get("Location").value, "/")
 

--- a/tests/features/packages/test_package_provider.py
+++ b/tests/features/packages/test_package_provider.py
@@ -10,12 +10,6 @@ class TestPackageProvider(TestCase):
     def test_config_is_merged(self):
         self.assertEqual(config("test_package.param_1"), 0)
 
-    # def test_package_config_can_be_published(self):
-    #     pp = self.application.providers[-1]
-    #     import pdb
-
-    #     pdb.set_trace()
-
     def test_views_are_registered(self):
         self.application.make("view").exists("test_package:package")
         self.application.make("view").exists("test_package:admin.settings")
@@ -33,10 +27,6 @@ class TestPackageProvider(TestCase):
         self.craft("test_package:command2").assertSuccess()
 
     def test_routes_are_registered(self):
-        # nb = len(self.application.make("router").routes)
-        # import pdb
-
-        # pdb.set_trace()
         for r in self.application.make("router").routes:
             print(r)
         self.get("/package/test/").assertContains("index")

--- a/tests/features/packages/test_package_provider.py
+++ b/tests/features/packages/test_package_provider.py
@@ -27,7 +27,5 @@ class TestPackageProvider(TestCase):
         self.craft("test_package:command2").assertSuccess()
 
     def test_routes_are_registered(self):
-        for r in self.application.make("router").routes:
-            print(r)
         self.get("/package/test/").assertContains("index")
         self.get("/api/package/test/").assertCreated()

--- a/tests/features/packages/test_package_provider.py
+++ b/tests/features/packages/test_package_provider.py
@@ -32,12 +32,12 @@ class TestPackageProvider(TestCase):
         self.craft("test_package:command1").assertSuccess()
         self.craft("test_package:command2").assertSuccess()
 
-    # def test_routes_are_registered(self):
-    #     # nb = len(self.application.make("router").routes)
-    #     # import pdb
+    def test_routes_are_registered(self):
+        # nb = len(self.application.make("router").routes)
+        # import pdb
 
-    #     # pdb.set_trace()
-    #     # for r in self.application.make("router").routes:
-    #     #     print(f"{r.url} -> {r._name}")
-    #     self.get("/package/test/").assertContains("index")
-    #     self.get("/api/package/test/").assertCreated()
+        # pdb.set_trace()
+        for r in self.application.make("router").routes:
+            print(r)
+        self.get("/package/test/").assertContains("index")
+        self.get("/api/package/test/").assertCreated()

--- a/tests/integrations/test_package/providers/MyTestPackageProvider.py
+++ b/tests/integrations/test_package/providers/MyTestPackageProvider.py
@@ -23,5 +23,5 @@ class MyTestPackageProvider(PackageProvider):
             .migrations("migrations/create_some_table.py")
             .assets("assets")
             .controllers("controllers")  # ensure this one is done before routes()
-            # .routes("routes/api.py", "routes/web.py")
+            .routes("routes/api.py", "routes/web.py")
         )

--- a/tests/tests/test_testcase.py
+++ b/tests/tests/test_testcase.py
@@ -32,20 +32,17 @@ class TestTestCase(TestCase):
 
     def test_add_routes(self):
         count = len(self.application.make("router").routes)
-        self.addRoutes(
-            Route.get("/test", "WelcomeController@show"),
-        )
+        print(count)
+        self.addRoutes(Route.get("/some-dumb-route", "WelcomeController@show"))
         self.assertEqual(len(self.application.make("router").routes), count + 1)
 
-    # def test_use_custom_test_response(self):
-    #     self.application.make("tests.response").add(
-    #         CustomTestResponse, OtherCustomTestResponse
-    #     )
-    #     # can use default assertions and custom from different classes
-    #     self.addRoutes(
-    #         Route.get("/", "WelcomeController@show"),
-    #     )
-    #     self.get("/").assertContains("Welcome").assertCustom().assertOtherCustom()
+    def test_use_custom_test_response(self):
+        self.application.make("tests.response").add(
+            CustomTestResponse, OtherCustomTestResponse
+        )
+        # can use default assertions and custom from different classes
+        self.addRoutes(Route.get("/", "WelcomeController@show"))
+        self.get("/").assertContains("Welcome").assertCustom().assertOtherCustom()
 
     def test_fake_time(self):
         given_date = pendulum.datetime(2015, 2, 5)

--- a/tests/tests/test_testcase.py
+++ b/tests/tests/test_testcase.py
@@ -32,8 +32,7 @@ class TestTestCase(TestCase):
 
     def test_add_routes(self):
         count = len(self.application.make("router").routes)
-        print(count)
-        self.addRoutes(Route.get("/some-dumb-route", "WelcomeController@show"))
+        self.addRoutes(Route.get("/some-route", "WelcomeController@show"))
         self.assertEqual(len(self.application.make("router").routes), count + 1)
 
     def test_use_custom_test_response(self):
@@ -83,11 +82,6 @@ class TestTestCase(TestCase):
 class TestTestingAssertions(TestCase):
     def setUp(self):
         super().setUp()
-        print(
-            "Initial routes before setRoutes():",
-            len(self.application.make("router").routes),
-        )
-        self.saved_routes = self.application.make("router").routes
         self.setRoutes(
             Route.get("/", "WelcomeController@show").name("home"),
             Route.get("/test", "WelcomeController@show").name("test"),
@@ -118,17 +112,6 @@ class TestTestingAssertions(TestCase):
             ).name("session"),
             Route.get("/test-session-2", "WelcomeController@session2").name("session2"),
             Route.get("/test-authenticates", "WelcomeController@auth").name("auth"),
-        )
-        print(
-            "Routes nb in TestAssertsions:", len(self.application.make("router").routes)
-        )
-
-    def tearDown(self):
-        super().tearDown()
-        self.application.make("router").routes = self.saved_routes
-        print(
-            "Routes nb in TestAssertsions backed up:",
-            len(self.application.make("router").routes),
         )
 
     def test_assert_contains(self):

--- a/tests/tests/test_testcase.py
+++ b/tests/tests/test_testcase.py
@@ -26,29 +26,26 @@ class OtherCustomTestResponse:
 
 
 class TestTestCase(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.setRoutes(
-            Route.get("/", "WelcomeController@show").name("home"),
-        )
-
     def tearDown(self):
         super().tearDown()
         self.restoreTime()
 
     def test_add_routes(self):
-        self.assertEqual(len(self.application.make("router").routes), 1)
+        count = len(self.application.make("router").routes)
         self.addRoutes(
-            Route.get("/test", "WelcomeController@show").name("test"),
+            Route.get("/test", "WelcomeController@show"),
         )
-        self.assertEqual(len(self.application.make("router").routes), 2)
+        self.assertEqual(len(self.application.make("router").routes), count + 1)
 
-    def test_use_custom_test_response(self):
-        self.application.make("tests.response").add(
-            CustomTestResponse, OtherCustomTestResponse
-        )
-        # can use default assertions and custom from different classes
-        self.get("/").assertContains("Welcome").assertCustom().assertOtherCustom()
+    # def test_use_custom_test_response(self):
+    #     self.application.make("tests.response").add(
+    #         CustomTestResponse, OtherCustomTestResponse
+    #     )
+    #     # can use default assertions and custom from different classes
+    #     self.addRoutes(
+    #         Route.get("/", "WelcomeController@show"),
+    #     )
+    #     self.get("/").assertContains("Welcome").assertCustom().assertOtherCustom()
 
     def test_fake_time(self):
         given_date = pendulum.datetime(2015, 2, 5)
@@ -89,6 +86,11 @@ class TestTestCase(TestCase):
 class TestTestingAssertions(TestCase):
     def setUp(self):
         super().setUp()
+        print(
+            "Initial routes before setRoutes():",
+            len(self.application.make("router").routes),
+        )
+        self.saved_routes = self.application.make("router").routes
         self.setRoutes(
             Route.get("/", "WelcomeController@show").name("home"),
             Route.get("/test", "WelcomeController@show").name("test"),
@@ -119,6 +121,17 @@ class TestTestingAssertions(TestCase):
             ).name("session"),
             Route.get("/test-session-2", "WelcomeController@session2").name("session2"),
             Route.get("/test-authenticates", "WelcomeController@auth").name("auth"),
+        )
+        print(
+            "Routes nb in TestAssertsions:", len(self.application.make("router").routes)
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        self.application.make("router").routes = self.saved_routes
+        print(
+            "Routes nb in TestAssertsions backed up:",
+            len(self.application.make("router").routes),
         )
 
     def test_assert_contains(self):

--- a/tests/tests/test_testcase.py
+++ b/tests/tests/test_testcase.py
@@ -26,21 +26,26 @@ class OtherCustomTestResponse:
 
 
 class TestTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.setRoutes(
+            Route.get("/", "WelcomeController@show").name("home"),
+        )
+
     def tearDown(self):
         super().tearDown()
         self.restoreTime()
 
     def test_add_routes(self):
-        count = len(self.application.make("router").routes)
+        self.assertEqual(len(self.application.make("router").routes), 1)
         self.addRoutes(Route.get("/some-route", "WelcomeController@show"))
-        self.assertEqual(len(self.application.make("router").routes), count + 1)
+        self.assertEqual(len(self.application.make("router").routes), 2)
 
     def test_use_custom_test_response(self):
         self.application.make("tests.response").add(
             CustomTestResponse, OtherCustomTestResponse
         )
         # can use default assertions and custom from different classes
-        self.addRoutes(Route.get("/", "WelcomeController@show"))
         self.get("/").assertContains("Welcome").assertCustom().assertOtherCustom()
 
     def test_fake_time(self):


### PR DESCRIPTION
When `setRoutes` or `addRoutes` method are called during tests, routes will be registered only during the lifetime of the test. This will ease having idempotent and isolated tests.

- Routes registering during tests has been cleaned. We won't end up with 300 routes at the end of the tests anymore
- It fixes #190 