### PR TITLE
Don't override files by default when using "make" commands

### DIFF
--- a/src/masonite/commands/AuthCommand.py
+++ b/src/masonite/commands/AuthCommand.py
@@ -1,10 +1,10 @@
 """Scaffold Auth Command."""
-from cleo import Command
 from distutils.dir_util import copy_tree
 import os
 
 from ..utils.location import controllers_path, views_path, mailables_path
 from ..utils.filesystem import get_module_dir
+from .Command import Command
 
 
 class AuthCommand(Command):

--- a/src/masonite/commands/Command.py
+++ b/src/masonite/commands/Command.py
@@ -1,0 +1,7 @@
+from cleo import Command as BaseCommand
+
+from ..utils.console import AddCommandColors
+
+
+class Command(BaseCommand, AddCommandColors):
+    pass

--- a/src/masonite/commands/InstallCommand.py
+++ b/src/masonite/commands/InstallCommand.py
@@ -2,7 +2,7 @@ import os
 import shutil
 from subprocess import call
 
-from cleo import Command
+from .Command import Command
 
 
 class InstallCommand(Command):

--- a/src/masonite/commands/InstallCommand.py
+++ b/src/masonite/commands/InstallCommand.py
@@ -44,7 +44,7 @@ class InstallCommand(Command):
             try:
                 self.call("key", "--store")
             except Exception:
-                self.line_error(
+                self.error(
                     "Could not successfully install Masonite. This could happen for several reasons but likely because of how Masonite is installed on your system and you could be hitting permission issues when Masonite is fetching required modules."
                     " If you have correctly followed the installation instructions then you should try everything again but start inside an virtual environment first to avoid any permission issues. If that does not work then seek help in"
                     " the Masonite Slack channel. Links can be found on GitHub in the main Masonite repo."

--- a/src/masonite/commands/KeyCommand.py
+++ b/src/masonite/commands/KeyCommand.py
@@ -1,6 +1,7 @@
 """New Key Command."""
-from cleo import Command
 from cryptography.fernet import Fernet
+
+from .Command import Command
 
 
 class KeyCommand(Command):

--- a/src/masonite/commands/MakeControllerCommand.py
+++ b/src/masonite/commands/MakeControllerCommand.py
@@ -1,10 +1,10 @@
 """New Controller Command."""
-from cleo import Command
 import inflection
 import os
 
 from ..utils.location import controllers_path
 from ..utils.filesystem import get_module_dir, render_stub_file
+from .Command import Command
 
 
 class MakeControllerCommand(Command):
@@ -14,6 +14,7 @@ class MakeControllerCommand(Command):
     controller
         {name : Name of the controller}
         {--r|--resource : Create a "resource" controller with the usual CRUD methods}
+        {--f|force=? : Force overriding file if already exists}
     """
 
     def __init__(self, application):
@@ -34,7 +35,14 @@ class MakeControllerCommand(Command):
         content = render_stub_file(stub_path, name)
 
         filename = f"{name}.py"
-        with open(controllers_path(filename), "w") as f:
+        path = controllers_path(filename)
+        if os.path.exists(path) and not self.option("force"):
+            self.warning(
+                f"{path} already exists! Run the command with -f (force) to override."
+            )
+            return -1
+
+        with open(path, "w") as f:
             f.write(content)
 
         self.info(f"Controller Created ({controllers_path(filename, absolute=False)})")

--- a/src/masonite/commands/MakeJobCommand.py
+++ b/src/masonite/commands/MakeJobCommand.py
@@ -1,10 +1,10 @@
 """New Key Command."""
-from cleo import Command
 import inflection
 import os
 
 from ..utils.filesystem import make_directory, render_stub_file, get_module_dir
 from ..utils.location import jobs_path
+from .Command import Command
 
 
 class MakeJobCommand(Command):
@@ -13,6 +13,7 @@ class MakeJobCommand(Command):
 
     job
         {name : Name of the job}
+        {--f|force=? : Force overriding file if already exists}
     """
 
     def __init__(self, application):
@@ -26,7 +27,11 @@ class MakeJobCommand(Command):
         filename = f"{name}.py"
         filepath = jobs_path(filename)
         make_directory(filepath)
-
+        if os.path.exists(filepath) and not self.option("force"):
+            self.warning(
+                f"{filepath} already exists! Run the command with -f (force) to override."
+            )
+            return -1
         with open(filepath, "w") as f:
             f.write(content)
         self.info(f"Job Created ({jobs_path(filename, absolute=False)})")

--- a/src/masonite/commands/MakeMailableCommand.py
+++ b/src/masonite/commands/MakeMailableCommand.py
@@ -1,11 +1,11 @@
 """New Mailable Command."""
-from cleo import Command
 import inflection
 import os
 
 from ..utils.filesystem import make_directory, render_stub_file, get_module_dir
 from ..utils.str import as_filepath
 from ..utils.location import base_path
+from .Command import Command
 
 
 class MakeMailableCommand(Command):
@@ -14,6 +14,7 @@ class MakeMailableCommand(Command):
 
     mailable
         {name : Name of the mailable}
+        {--f|force=? : Force overriding file if already exists}
     """
 
     def __init__(self, application):
@@ -29,7 +30,11 @@ class MakeMailableCommand(Command):
         )
         filepath = base_path(relative_filename)
         make_directory(filepath)
-
+        if os.path.exists(filepath) and not self.option("force"):
+            self.warning(
+                f"{filepath} already exists! Run the command with -f (force) to override."
+            )
+            return -1
         with open(filepath, "w") as f:
             f.write(content)
 

--- a/src/masonite/commands/MakePolicyCommand.py
+++ b/src/masonite/commands/MakePolicyCommand.py
@@ -1,9 +1,9 @@
 """New Policy Command."""
 import inflection
 import os
-from cleo import Command
 
 from ..utils.filesystem import make_directory
+from .Command import Command
 
 
 class MakePolicyCommand(Command):
@@ -12,7 +12,8 @@ class MakePolicyCommand(Command):
 
     policy
         {name : Name of the policy}
-        {--model=? : Create a policy for a model with a set of predefined methods}
+        {--m|model=? : Create a policy for a model with a set of predefined methods}
+        {--f|force=? : Force overriding file if already exists}
     """
 
     def __init__(self, application):
@@ -38,6 +39,11 @@ class MakePolicyCommand(Command):
         )
 
         make_directory(file_name)
+        if os.path.exists(file_name) and not self.option("force"):
+            self.warning(
+                f"{file_name} already exists! Run the command with -f (force) to override."
+            )
+            return -1
 
         with open(file_name, "w") as f:
             f.write(content)

--- a/src/masonite/commands/MakeProviderCommand.py
+++ b/src/masonite/commands/MakeProviderCommand.py
@@ -1,11 +1,11 @@
 """New Provider Command."""
-from cleo import Command
 import inflection
 import os
 
 from ..utils.filesystem import make_directory, render_stub_file, get_module_dir
 from ..utils.str import as_filepath
 from ..utils.location import base_path
+from .Command import Command
 
 
 class MakeProviderCommand(Command):
@@ -14,6 +14,7 @@ class MakeProviderCommand(Command):
 
     provider
         {name : Name of the provider}
+        {--f|force=? : Force overriding file if already exists}
     """
 
     def __init__(self, application):
@@ -30,6 +31,11 @@ class MakeProviderCommand(Command):
         )
         filepath = base_path(relative_filename)
         make_directory(filepath)
+        if os.path.exists(filepath) and not self.option("force"):
+            self.warning(
+                f"{filepath} already exists! Run the command with -f (force) to override."
+            )
+            return -1
 
         with open(filepath, "w") as f:
             f.write(content)

--- a/src/masonite/commands/MakeTestCommand.py
+++ b/src/masonite/commands/MakeTestCommand.py
@@ -1,9 +1,9 @@
 """New Test Command."""
-from cleo import Command
 import inflection
 import os
 
 from ..utils.filesystem import make_directory, render_stub_file, get_module_dir
+from .Command import Command
 
 
 class MakeTestCommand(Command):
@@ -13,6 +13,7 @@ class MakeTestCommand(Command):
     test
         {name : Name of the test case (CamelCase) }
         {--d|--directory=tests/unit : Directory to create the test file}
+        {--f|force=? : Force overriding file if already exists}
     """
 
     def __init__(self, application):
@@ -27,6 +28,11 @@ class MakeTestCommand(Command):
 
         filepath = os.path.join(directory, test_filename)
         make_directory(filepath)
+        if os.path.exists(filepath) and not self.option("force"):
+            self.warning(
+                f"{filepath} already exists! Run the command with -f (force) to override."
+            )
+            return -1
         with open(filepath, "w") as f:
             f.write(content)
         self.info(f"Test Created ({filepath})")

--- a/src/masonite/commands/ProjectCommand.py
+++ b/src/masonite/commands/ProjectCommand.py
@@ -1,4 +1,3 @@
-from cleo import Command
 import os
 import shutil
 import zipfile
@@ -12,6 +11,7 @@ from ..exceptions import (
     ProjectProviderHttpError,
     ProjectTargetNotEmpty,
 )
+from .Command import Command
 
 
 class ProjectCommand(Command):

--- a/src/masonite/commands/ProjectCommand.py
+++ b/src/masonite/commands/ProjectCommand.py
@@ -54,7 +54,7 @@ class ProjectCommand(Command):
 
         try:
             if repo and provider not in self.providers:
-                return self.line_error(
+                return self.error(
                     "'provider' option must be in {}".format(",".join(self.providers))
                 )
 
@@ -72,7 +72,7 @@ class ProjectCommand(Command):
             if branch != "False":
                 branch_data = self.get_branch_provider_data(provider, branch)
                 if "name" not in branch_data:
-                    return self.line_error("Branch {0} does not exist.".format(branch))
+                    return self.error("Branch {0} does not exist.".format(branch))
 
                 zipball = self.get_branch_archive_url(provider, repo, branch)
             elif version != "False":
@@ -89,9 +89,7 @@ class ProjectCommand(Command):
                         )
                         break
                 if zipball is False:
-                    return self.line_error(
-                        "Version {0} could not be found".format(version)
-                    )
+                    return self.error("Version {0} could not be found".format(version))
             else:
                 tags_data = self.get_releases_provider_data(provider)
 
@@ -126,7 +124,7 @@ class ProjectCommand(Command):
                 )
             )
         except Exception as e:
-            self.line_error(
+            self.error(
                 "The following error happened when crafting your project. Verify options are correct else open an issue at https://github.com/MasoniteFramework/masonite."
             )
             raise e
@@ -148,7 +146,7 @@ class ProjectCommand(Command):
                 )
             success = True
         except Exception as e:
-            self.line_error("An error occured when downloading {0}".format(zipurl))
+            self.error("An error occured when downloading {0}".format(zipurl))
             raise e
 
         if success:

--- a/src/masonite/commands/PublishPackageCommand.py
+++ b/src/masonite/commands/PublishPackageCommand.py
@@ -24,7 +24,7 @@ class PublishPackageCommand(Command):
             if isinstance(provider, PackageProvider) and provider.package.name == name:
                 selected_provider = provider
         if not selected_provider:
-            self.line_error(
+            self.error(
                 f"No package has been registered under the name {name}.", style="error"
             )
             return

--- a/src/masonite/commands/PublishPackageCommand.py
+++ b/src/masonite/commands/PublishPackageCommand.py
@@ -24,9 +24,7 @@ class PublishPackageCommand(Command):
             if isinstance(provider, PackageProvider) and provider.package.name == name:
                 selected_provider = provider
         if not selected_provider:
-            self.error(
-                f"No package has been registered under the name {name}.", style="error"
-            )
+            self.error(f"No package has been registered under the name {name}.")
             return
 
         if self.option("resources"):

--- a/src/masonite/commands/PublishPackageCommand.py
+++ b/src/masonite/commands/PublishPackageCommand.py
@@ -1,4 +1,4 @@
-from cleo import Command
+from .Command import Command
 
 
 class PublishPackageCommand(Command):

--- a/src/masonite/commands/QueueFailedCommand.py
+++ b/src/masonite/commands/QueueFailedCommand.py
@@ -1,10 +1,10 @@
-"""New Key Command."""
-from cleo import Command
+"""Queue Failed Command."""
 import os
 
 from ..utils.filesystem import make_directory, get_module_dir
 from ..utils.time import migration_timestamp
 from ..utils.location import base_path
+from .Command import Command
 
 
 class QueueFailedCommand(Command):

--- a/src/masonite/commands/QueueRetryCommand.py
+++ b/src/masonite/commands/QueueRetryCommand.py
@@ -1,5 +1,5 @@
-"""New Key Command."""
-from cleo import Command
+"""Queue Retry Command."""
+from .Command import Command
 
 
 class QueueRetryCommand(Command):

--- a/src/masonite/commands/QueueTableCommand.py
+++ b/src/masonite/commands/QueueTableCommand.py
@@ -1,10 +1,10 @@
 """New Queue Table Command."""
-from cleo import Command
 import os
 
 from ..utils.filesystem import make_directory, get_module_dir
 from ..utils.time import migration_timestamp
 from ..utils.location import base_path
+from .Command import Command
 
 
 class QueueTableCommand(Command):

--- a/src/masonite/commands/QueueWorkCommand.py
+++ b/src/masonite/commands/QueueWorkCommand.py
@@ -1,5 +1,5 @@
 """Queue Work Command."""
-from cleo import Command
+from .Command import Command
 
 
 class QueueWorkCommand(Command):

--- a/src/masonite/commands/ServeCommand.py
+++ b/src/masonite/commands/ServeCommand.py
@@ -2,7 +2,7 @@ import sys
 
 import hupper
 import waitress
-from cleo import Command
+from .Command import Command
 
 
 class ServeCommand(Command):

--- a/src/masonite/commands/TinkerCommand.py
+++ b/src/masonite/commands/TinkerCommand.py
@@ -3,7 +3,6 @@ import os
 import code
 import sys
 import pendulum
-from cleo import Command
 
 from ..environment import env
 from ..configuration import config
@@ -12,6 +11,7 @@ from ..utils.structures import load, data_get
 from ..utils.location import base_path, config_path, models_path
 from ..helpers import optional, url
 from ..facades import Loader
+from .Command import Command
 
 
 BANNER = """Masonite Python \033[92m {} \033[0m Console

--- a/src/masonite/notification/commands/MakeNotificationCommand.py
+++ b/src/masonite/notification/commands/MakeNotificationCommand.py
@@ -1,11 +1,11 @@
 """New Notification Command"""
-from cleo import Command
 import inflection
 import os
 
 from ...utils.filesystem import get_module_dir, make_directory, render_stub_file
 from ...utils.location import base_path
 from ...utils.str import as_filepath
+from ...commands.Command import Command
 
 
 class MakeNotificationCommand(Command):
@@ -14,6 +14,7 @@ class MakeNotificationCommand(Command):
 
     notification
         {name : Name of the notification}
+        {--f|force=? : Force overriding file if already exists}
     """
 
     def __init__(self, application):
@@ -30,7 +31,11 @@ class MakeNotificationCommand(Command):
         )
         filepath = base_path(relative_filename)
         make_directory(filepath)
-
+        if os.path.exists(filepath) and not self.option("force"):
+            self.warning(
+                f"{filepath} already exists! Run the command with -f (force) to override."
+            )
+            return -1
         with open(filepath, "w") as f:
             f.write(content)
 

--- a/src/masonite/scheduling/commands/MakeTaskCommand.py
+++ b/src/masonite/scheduling/commands/MakeTaskCommand.py
@@ -1,12 +1,11 @@
 """New Task Command """
 import os
 import inflection
-from cleo import Command
-from os.path import exists
 
 from ...utils.filesystem import make_directory, get_module_dir, render_stub_file
 from ...utils.location import base_path
 from ...utils.str import as_filepath
+from ...commands.Command import Command
 
 
 class MakeTaskCommand(Command):
@@ -15,6 +14,7 @@ class MakeTaskCommand(Command):
     task
         {name : Name of the task you want to create}
         {--d|--directory=? : Override the directory to create the task in}
+        {--f|force=? : Force overriding file if already exists}
     """
 
     def __init__(self, application):
@@ -31,10 +31,11 @@ class MakeTaskCommand(Command):
         )
         filepath = base_path(relative_file_name)
 
-        if exists(relative_file_name):
-            return self.line_error(
-                f"Task already exists at: {relative_file_name}", style="error"
+        if os.path.exists(relative_file_name) and not self.option("force"):
+            self.warning(
+                f"{relative_file_name} already exists! Run the command with -f (force) to override."
             )
+            return -1
 
         make_directory(filepath)
         with open(filepath, "w") as fp:

--- a/src/masonite/utils/console.py
+++ b/src/masonite/utils/console.py
@@ -12,3 +12,28 @@ class HasColoredOutput:
 
     def info(self, message):
         return self.success(message)
+
+
+class AddCommandColors:
+    """The default style set used by Cleo is defined here:
+    https://github.com/sdispater/clikit/blob/master/src/clikit/formatter/default_style_set.py
+    This mixin add method helper to output errors and warnings.
+    """
+
+    def error(self, text):
+        """
+        Write a string as information output.
+
+        :param text: The line to write
+        :type text: str
+        """
+        self.line(text, "error")
+
+    def warning(self, text):
+        """
+        Write a string as information output.
+
+        :param text: The line to write
+        :type text: str
+        """
+        self.line(text, "c2")

--- a/src/masonite/validation/commands/MakeRuleCommand.py
+++ b/src/masonite/validation/commands/MakeRuleCommand.py
@@ -1,11 +1,11 @@
 """New Rule Command."""
-from cleo import Command
 import inflection
 import os
 
 from ...utils.filesystem import get_module_dir, make_directory, render_stub_file
 from ...utils.location import base_path
 from ...utils.str import as_filepath
+from ...commands.Command import Command
 
 
 class MakeRuleCommand(Command):
@@ -14,6 +14,7 @@ class MakeRuleCommand(Command):
 
     rule
         {name : Name of the rule}
+        {--f|force=? : Force overriding file if already exists}
     """
 
     def __init__(self, application):
@@ -29,10 +30,11 @@ class MakeRuleCommand(Command):
             as_filepath(self.app.make("validation.location")), name + ".py"
         )
 
-        if os.path.exists(relative_filename):
-            return self.line(
-                f"<error>File ({relative_filename}) already exists</error>"
+        if os.path.exists(relative_filename) and not self.option("force"):
+            self.warning(
+                f"{relative_filename} already exists! Run the command with -f (force) to override."
             )
+            return -1
 
         filepath = base_path(relative_filename)
         make_directory(filepath)

--- a/src/masonite/validation/commands/MakeRuleEnclosureCommand.py
+++ b/src/masonite/validation/commands/MakeRuleEnclosureCommand.py
@@ -1,11 +1,11 @@
 """New Rule Enclosure Command."""
-from cleo import Command
 import inflection
 import os
 
 from ...utils.filesystem import get_module_dir, make_directory, render_stub_file
 from ...utils.location import base_path
 from ...utils.str import as_filepath
+from ...commands.Command import Command
 
 
 class MakeRuleEnclosureCommand(Command):
@@ -28,10 +28,12 @@ class MakeRuleEnclosureCommand(Command):
             as_filepath(self.app.make("validation.location")), name + ".py"
         )
 
-        if os.path.exists(relative_filename):
-            return self.line(
-                f"<error>File ({relative_filename}) already exists</error>"
+        if os.path.exists(relative_filename) and not self.option("force"):
+            self.warning(
+                f"{relative_filename} already exists! Run the command with -f (force) to override."
             )
+            return -1
+
         filepath = base_path(relative_filename)
         make_directory(filepath)
 


### PR DESCRIPTION
All "make" commands now have a force option to avoid overriding the file. A warning is displayed and the command stops.
The user is invited to use `--force` flag to override the file.

Also line_error() was used and sometimes without style="error" so to be more consistent, now all commands use and can access:
```python
self.info()
self.comment()
self.warning()
self.error()
```