### PR TITLE
Add `routes:list` command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ setup(
         "masonite.request",
         "masonite.response",
         "masonite.routes",
+        "masonite.routes.commands",
         "masonite.scheduling.commands",
         "masonite.scheduling.providers",
         "masonite.scheduling",

--- a/src/masonite/providers/RouteProvider.py
+++ b/src/masonite/providers/RouteProvider.py
@@ -5,6 +5,7 @@ from ..facades import Response as ResponseFacade
 from .Provider import Provider
 from ..routes import Route
 from ..pipeline import Pipeline
+from ..routes.commands import RouteListCommand
 
 
 class RouteProvider(Provider):
@@ -14,6 +15,7 @@ class RouteProvider(Provider):
     def register(self):
         # Register the routes?
         Route.set_controller_locations(self.application.make("controllers.location"))
+        self.application.make("commands").add(RouteListCommand(self.application))
 
     def boot(self):
         router = self.application.make("router")

--- a/src/masonite/routes/commands/RouteListCommand.py
+++ b/src/masonite/routes/commands/RouteListCommand.py
@@ -1,0 +1,64 @@
+"""Route List Command"""
+import re
+from cleo import Command
+
+
+class RouteListCommand(Command):
+    """
+    List all your application routes.
+
+    routes:list
+        {--M|methods= : Filter by a list of HTTP methods: GET or GET,POST}
+        {--N|name= : Filter by route name}
+    """
+
+    def __init__(self, application):
+        super().__init__()
+        self.app = application
+
+    def handle(self):
+        # get filters
+        methods = self.option("methods")
+        if methods:
+            methods = list(map(lambda m: m.lower(), methods.split(",")))
+        name = self.option("name")
+
+        # get routes
+        router = self.app.make("router")
+        routes = router.routes
+
+        # filter by HTTP methods
+        if methods:
+            routes = list(
+                filter(
+                    lambda route: set(route.request_method).intersection(methods),
+                    routes,
+                )
+            )
+        # filter by name
+        if name:
+            routes = list(
+                filter(
+                    lambda route: re.findall(
+                        name, route.get_name() or "", re.IGNORECASE
+                    ),
+                    routes,
+                )
+            )
+
+        # build routes table
+        header = ["URI", "Name", "Method(s)", "Controller", "Middleware(s)"]
+        rows = list(map(lambda route: self.format_route_as_row(route), routes))
+        rows.sort()
+        self.render_table(header, rows)
+
+    def format_route_as_row(self, route):
+        """Format a Route object as a table row."""
+        row = [
+            route.url,
+            route.get_name() or "",
+            "/".join(map(lambda m: m.upper(), route.request_method)),
+            route.controller,
+            ",".join(route.list_middleware),
+        ]
+        return row

--- a/src/masonite/routes/commands/__init__.py
+++ b/src/masonite/routes/commands/__init__.py
@@ -1,0 +1,1 @@
+from .RouteListCommand import RouteListCommand


### PR DESCRIPTION
This PR adds a simple command to list routes registered in a Masonite app ! It comes with simple filtering by HTTP methods and route name (case insensitive match). Routes are sorted alphabetically and displayed as a table.

```
python craft routes:list
```

```
python craft routes:list --methods GET,POST
```

```
python craft routes:list --name welcome
```
<img width="934" alt="image" src="https://user-images.githubusercontent.com/9897999/147240755-a6f3e303-2a29-472b-97db-8f78edaf83ce.png">
